### PR TITLE
YoutubeSignatureCipher -> Add Getter for scriptTimestamp

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeSignatureCipher.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeSignatureCipher.java
@@ -60,4 +60,11 @@ public class YoutubeSignatureCipher {
   public void setTimestamp(String timestamp) {
     scriptTimestamp = timestamp;
   }
+
+  /**
+   * @return The current script timestamp
+   */
+  public String getScriptTimestamp() {
+    return scriptTimestamp;
+  }
 }


### PR DESCRIPTION
I would appreciate if this getter could be included within the fork. I am in the process of switching over from sed's lavaplayer and some of my custom work around the lavaplayer library needs access to that variable. Hope this is okay. 