### PR TITLE
Fixes missing implementation in Pcm16AudioDataFormat

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/format/Pcm16AudioDataFormat.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/format/Pcm16AudioDataFormat.java
@@ -30,7 +30,7 @@ public class Pcm16AudioDataFormat extends AudioDataFormat {
 
   @Override
   public String codecName() {
-    return CODEC_NAME_BE;
+    return bigEndian ? CODEC_NAME_BE : CODEC_NAME_LE;
   }
 
   @Override


### PR DESCRIPTION
The method always returns the Big Endian string, no matter if bigEndian is set or not. I have fixed that.

I tested it with the javax.sound.* implementation but not with any Discord stuff.