### PR TITLE
fix audio issues with xm extension

### DIFF
--- a/extensions/format-xm/src/main/java/com/sedmelluq/lavaplayer/extensions/format/xm/XmTrackProvider.java
+++ b/extensions/format-xm/src/main/java/com/sedmelluq/lavaplayer/extensions/format/xm/XmTrackProvider.java
@@ -24,7 +24,7 @@ public class XmTrackProvider {
 
     while ((blockCount = ibxm.getAudio(buffer)) > 0) {
       for (int i = 0; i < blocksInBuffer; i++) {
-        shortBuffer[i] = (short) buffer[i];
+        shortBuffer[i] = (short) Math.max(-32678, Math.min(buffer[i], 32767));
       }
 
       downstream.process(shortBuffer, 0, blockCount * 2);


### PR DESCRIPTION
As is, the xm extension has a lot of audio clipping issues along with just sounding really bad on some mod files. Take a listen on this one included below:
[stq-fluid_combustion.zip](https://github.com/Walkyst/lavaplayer-fork/files/7817148/stq-fluid_combustion.zip)
The fix is to properly clamp the values instead of just directly converting an int to a short.