### PR TITLE
Fix YouTube searching.

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeSearchProvider.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeSearchProvider.java
@@ -90,14 +90,15 @@ public class YoutubeSearchProvider implements YoutubeSearchResultLoader {
     jsonBrowser.get("contents")
             .get("sectionListRenderer")
             .get("contents")
-            .index(0)
-            .get("itemSectionRenderer")
-            .get("contents")
-            .values()
-            .forEach(jsonTrack -> {
-              AudioTrack track = extractPolymerData(jsonTrack, trackFactory);
-              if (track != null) list.add(track);
-            });
+            .values() // .index(0)
+            .forEach(content -> content.get("itemSectionRenderer")
+                    .get("contents")
+                    .values()
+                    .forEach(jsonTrack -> {
+                      AudioTrack track = extractPolymerData(jsonTrack, trackFactory);
+                      if (track != null) list.add(track);
+                    })
+            );
     return list;
   }
 


### PR DESCRIPTION
This change checks all nodes for `compactVideoRenderer` existence, rather than a set index, as it's no longer guaranteed that the node containing `compactVideoRenderer` will be in the same position each time.