### PR TITLE
Force YT HTTP stream to use the range header and reconnect

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubePersistentHttpStream.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubePersistentHttpStream.java
@@ -23,8 +23,6 @@ public class YoutubePersistentHttpStream extends PersistentHttpStream {
 
   @Override
   protected URI getConnectUrl() {
-    //System.out.printf("getConnectUrl() with position %d, clen %d%n", position, contentLength);
-
     if (position > 0) {
       try {
         return new URIBuilder(contentUrl).addParameter("range", position + "-" + contentLength).build();

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubePersistentHttpStream.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubePersistentHttpStream.java
@@ -18,11 +18,13 @@ public class YoutubePersistentHttpStream extends PersistentHttpStream {
    * @param contentLength The length of the resource in bytes
    */
   public YoutubePersistentHttpStream(HttpInterface httpInterface, URI contentUrl, long contentLength) {
-    super(httpInterface, contentUrl, contentLength);
+    super(httpInterface, contentUrl, contentLength, 0L);
   }
 
   @Override
   protected URI getConnectUrl() {
+    //System.out.printf("getConnectUrl() with position %d, clen %d%n", position, contentLength);
+
     if (position > 0) {
       try {
         return new URIBuilder(contentUrl).addParameter("range", position + "-" + contentLength).build();

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/io/PersistentHttpStream.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/io/PersistentHttpStream.java
@@ -51,6 +51,20 @@ public class PersistentHttpStream extends SeekableInputStream implements AutoClo
   }
 
   /**
+   * @param httpInterface The HTTP interface to use for requests
+   * @param contentUrl The URL of the resource
+   * @param contentLength The length of the resource in bytes
+   * @param maxSkipDistance The maximum skip distance in bytes
+   */
+  public PersistentHttpStream(HttpInterface httpInterface, URI contentUrl, Long contentLength, long maxSkipDistance) {
+    super(contentLength == null ? Units.CONTENT_LENGTH_UNKNOWN : contentLength, maxSkipDistance);
+
+    this.httpInterface = httpInterface;
+    this.contentUrl = contentUrl;
+    this.position = 0;
+  }
+
+  /**
    * Connect and return status code or return last status code if already connected. This causes the internal status
    * code checker to be disabled, so non-success status codes will be returned instead of being thrown as they would
    * be otherwise.


### PR DESCRIPTION
This PR sets the `maxSkipDistance` in `PersistentHttpStream` to 0, which forces usage of the `seekHard` method, which sets the position and closes the connection.

The automatic retry mechanism re-opens the connection, however as YT supports the `range` header, means they do the seeking on their end, serving the file from the provided byte range (`range=byteStart-byteEnd`). This is how the YouTube player does seeking outside of pre-buffered ranges, and should provide more consistent and reliable seeking for YT tracks.