### PR TITLE
Bump dependencies to resolve multiple Vulnerabilities

### DIFF
--- a/main/build.gradle.kts
+++ b/main/build.gradle.kts
@@ -12,20 +12,20 @@ dependencies {
   implementation("com.github.walkyst:lavaplayer-natives-fork:1.0.1")
   implementation("com.github.walkyst.JAADec-fork:jaadec-ext-aac:0.1.3")
   implementation("org.mozilla:rhino-engine:1.7.14")
-  api("org.slf4j:slf4j-api:1.7.25")
+  api("org.slf4j:slf4j-api:2.0.0")
 
-  api("org.apache.httpcomponents:httpclient:4.5.10")
-  implementation("commons-io:commons-io:2.6")
+  api("org.apache.httpcomponents.client5:httpclient5:5.2-beta1")
+  implementation("commons-io:commons-io:2.11.0")
 
-  api("com.fasterxml.jackson.core:jackson-core:2.10.0")
-  api("com.fasterxml.jackson.core:jackson-databind:2.10.0")
+  api("com.fasterxml.jackson.core:jackson-core:2.13.4")
+  api("com.fasterxml.jackson.core:jackson-databind:2.13.4")
 
-  implementation("org.jsoup:jsoup:1.12.1")
+  implementation("org.jsoup:jsoup:1.15.3")
   implementation("net.iharder:base64:2.3.9")
 
-  testImplementation("org.codehaus.groovy:groovy:2.5.5")
-  testImplementation("org.spockframework:spock-core:1.2-groovy-2.5")
-  testImplementation("ch.qos.logback:logback-classic:1.2.3")
+  testImplementation("org.codehaus.groovy:groovy:3.0.12")
+  testImplementation("org.spockframework:spock-core:2.2-groovy-2.5")
+  testImplementation("ch.qos.logback:logback-classic:1.4.0")
   testImplementation("com.sedmelluq:lavaplayer-test-samples:1.3.11")
 }
 


### PR DESCRIPTION
Continuation of PR #60 update httpClient to client5 as it has moved to a new repo, along with a few more CVE vulnerabilities in commons and other depends.