### PR TITLE
[Bandcamp] Don't assume mediaUrl exists

### DIFF
--- a/main/build.gradle.kts
+++ b/main/build.gradle.kts
@@ -23,6 +23,8 @@ dependencies {
   implementation("org.jsoup:jsoup:1.12.1")
   implementation("net.iharder:base64:2.3.9")
 
+  implementation("com.grack:nanojson:1.7")
+
   testImplementation("org.codehaus.groovy:groovy:2.5.5")
   testImplementation("org.spockframework:spock-core:1.2-groovy-2.5")
   testImplementation("ch.qos.logback:logback-classic:1.2.3")

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/filter/ResamplingPcmAudioFilter.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/filter/ResamplingPcmAudioFilter.java
@@ -73,6 +73,8 @@ public class ResamplingPcmAudioFilter implements FloatPcmAudioFilter {
 
   private static SampleRateConverter.ResamplingType getResamplingType(AudioConfiguration.ResamplingQuality quality) {
     switch (quality) {
+      case HIGHEST:
+        return SampleRateConverter.ResamplingType.SINC_BEST_QUALITY;
       case HIGH:
         return SampleRateConverter.ResamplingType.SINC_MEDIUM_QUALITY;
       case MEDIUM:

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/player/AudioConfiguration.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/player/AudioConfiguration.java
@@ -32,59 +32,64 @@ public class AudioConfiguration {
     return resamplingQuality;
   }
 
-  public void setResamplingQuality(ResamplingQuality resamplingQuality) {
+  public AudioConfiguration setResamplingQuality(ResamplingQuality resamplingQuality) {
     this.resamplingQuality = resamplingQuality;
+    return this;
   }
 
   public int getOpusEncodingQuality() {
     return opusEncodingQuality;
   }
 
-  public void setOpusEncodingQuality(int opusEncodingQuality) {
+  public AudioConfiguration setOpusEncodingQuality(int opusEncodingQuality) {
     this.opusEncodingQuality = Math.max(0, Math.min(opusEncodingQuality, OPUS_QUALITY_MAX));
+    return this;
   }
 
   public AudioDataFormat getOutputFormat() {
     return outputFormat;
   }
 
-  public void setOutputFormat(AudioDataFormat outputFormat) {
+  public AudioConfiguration setOutputFormat(AudioDataFormat outputFormat) {
     this.outputFormat = outputFormat;
+    return this;
   }
 
   public boolean isFilterHotSwapEnabled() {
     return filterHotSwapEnabled;
   }
 
-  public void setFilterHotSwapEnabled(boolean filterHotSwapEnabled) {
+  public AudioConfiguration setFilterHotSwapEnabled(boolean filterHotSwapEnabled) {
     this.filterHotSwapEnabled = filterHotSwapEnabled;
+    return this;
   }
 
   public AudioFrameBufferFactory getFrameBufferFactory() {
     return frameBufferFactory;
   }
 
-  public void setFrameBufferFactory(AudioFrameBufferFactory frameBufferFactory) {
+  public AudioConfiguration setFrameBufferFactory(AudioFrameBufferFactory frameBufferFactory) {
     this.frameBufferFactory = frameBufferFactory;
+    return this;
   }
 
   /**
    * @return A copy of this configuration.
    */
   public AudioConfiguration copy() {
-    AudioConfiguration copy = new AudioConfiguration();
-    copy.setResamplingQuality(resamplingQuality);
-    copy.setOpusEncodingQuality(opusEncodingQuality);
-    copy.setOutputFormat(outputFormat);
-    copy.setFilterHotSwapEnabled(filterHotSwapEnabled);
-    copy.setFrameBufferFactory(frameBufferFactory);
-    return copy;
+    return new AudioConfiguration()
+            .setResamplingQuality(resamplingQuality)
+            .setOpusEncodingQuality(opusEncodingQuality)
+            .setOutputFormat(outputFormat)
+            .setFilterHotSwapEnabled(filterHotSwapEnabled)
+            .setFrameBufferFactory(frameBufferFactory);
   }
 
   /**
    * Resampling quality levels
    */
   public enum ResamplingQuality {
+    HIGHEST,
     HIGH,
     MEDIUM,
     LOW

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/bandcamp/BandcampAudioTrack.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/bandcamp/BandcampAudioTrack.java
@@ -2,6 +2,8 @@ package com.sedmelluq.discord.lavaplayer.source.bandcamp;
 
 import com.sedmelluq.discord.lavaplayer.container.mp3.Mp3AudioTrack;
 import com.sedmelluq.discord.lavaplayer.source.AudioSourceManager;
+import com.sedmelluq.discord.lavaplayer.tools.FriendlyException;
+import com.sedmelluq.discord.lavaplayer.tools.FriendlyException.Severity;
 import com.sedmelluq.discord.lavaplayer.tools.JsonBrowser;
 import com.sedmelluq.discord.lavaplayer.tools.io.HttpClientTools;
 import com.sedmelluq.discord.lavaplayer.tools.io.HttpInterface;
@@ -43,6 +45,11 @@ public class BandcampAudioTrack extends DelegatedAudioTrack {
       log.debug("Loading Bandcamp track page from URL: {}", trackInfo.identifier);
 
       String trackMediaUrl = getTrackMediaUrl(httpInterface);
+
+      if (trackMediaUrl == null) {
+        throw new FriendlyException("No supported formats for this track", Severity.SUSPICIOUS, null);
+      }
+
       log.debug("Starting Bandcamp track from URL: {}", trackMediaUrl);
 
       try (PersistentHttpStream stream = new PersistentHttpStream(httpInterface, new URI(trackMediaUrl), null)) {

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/BaseYoutubeHttpContextFilter.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/BaseYoutubeHttpContextFilter.java
@@ -8,10 +8,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class BaseYoutubeHttpContextFilter implements HttpContextFilter {
-  private static final Logger log = LoggerFactory.getLogger(BaseYoutubeHttpContextFilter.class);
-
-  public static final String androidClientContext = "android-client-req";
-
   @Override
   public void onContextOpen(HttpClientContext context) {
 
@@ -26,11 +22,6 @@ public class BaseYoutubeHttpContextFilter implements HttpContextFilter {
   public void onRequest(HttpClientContext context, HttpUriRequest request, boolean isRepetition) {
     // Consent cookie, so we do not land on consent page for HTML requests
     request.addHeader("Cookie", "CONSENT=YES+cb.20210328-17-p0.en+FX+471");
-
-    if (context.getAttribute(androidClientContext) == Boolean.TRUE) {
-      log.info("Applying android user-agent header.");
-      request.setHeader("user-agent", "com.google.android.youtube/17.39.35 (Linux; U; Android 11) gzip");
-    }
   }
 
   @Override

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/BaseYoutubeHttpContextFilter.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/BaseYoutubeHttpContextFilter.java
@@ -4,8 +4,12 @@ import com.sedmelluq.discord.lavaplayer.tools.http.HttpContextFilter;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.protocol.HttpClientContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class BaseYoutubeHttpContextFilter implements HttpContextFilter {
+  private static final Logger log = LoggerFactory.getLogger(BaseYoutubeHttpContextFilter.class);
+
   public static final String androidClientContext = "android-client-req";
 
   @Override
@@ -24,6 +28,7 @@ public class BaseYoutubeHttpContextFilter implements HttpContextFilter {
     request.addHeader("Cookie", "CONSENT=YES+cb.20210328-17-p0.en+FX+471");
 
     if (context.getAttribute(androidClientContext) == Boolean.TRUE) {
+      log.info("Applying android user-agent header.");
       request.setHeader("user-agent", "com.google.android.youtube/17.39.35 (Linux; U; Android 11) gzip");
     }
   }

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/BaseYoutubeHttpContextFilter.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/BaseYoutubeHttpContextFilter.java
@@ -6,6 +6,8 @@ import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.protocol.HttpClientContext;
 
 public class BaseYoutubeHttpContextFilter implements HttpContextFilter {
+  public static final String androidClientContext = "android-client-req";
+
   @Override
   public void onContextOpen(HttpClientContext context) {
 
@@ -20,6 +22,10 @@ public class BaseYoutubeHttpContextFilter implements HttpContextFilter {
   public void onRequest(HttpClientContext context, HttpUriRequest request, boolean isRepetition) {
     // Consent cookie, so we do not land on consent page for HTML requests
     request.addHeader("Cookie", "CONSENT=YES+cb.20210328-17-p0.en+FX+471");
+
+    if (context.getAttribute(androidClientContext) == Boolean.TRUE) {
+      request.setHeader("user-agent", "com.google.android.youtube/17.39.35 (Linux; U; Android 11) gzip");
+    }
   }
 
   @Override

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubePlaylistLoader.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubePlaylistLoader.java
@@ -36,7 +36,7 @@ public class DefaultYoutubePlaylistLoader implements YoutubePlaylistLoader {
   public AudioPlaylist load(HttpInterface httpInterface, String playlistId, String selectedVideoId,
                             Function<AudioTrackInfo, AudioTrack> trackFactory) {
     HttpPost post = new HttpPost(BROWSE_URL);
-    String clientJson = YoutubeClientConfig.ANDROID_CLIENT.copy()
+    String clientJson = YoutubeClientConfig.ANDROID.copy()
             .withRootField("browseId", "VL" + playlistId)
             .toJsonString();
     StringEntity payload = new StringEntity(clientJson, "UTF-8");
@@ -90,7 +90,7 @@ public class DefaultYoutubePlaylistLoader implements YoutubePlaylistLoader {
     // Also load the next pages, each result gives us a JSON with separate values for list html and next page loader html
     while (continuationsToken != null && ++loadCount < pageCount) {
       HttpPost post = new HttpPost(BROWSE_URL);
-      String clientJson = YoutubeClientConfig.ANDROID_CLIENT.copy()
+      String clientJson = YoutubeClientConfig.ANDROID.copy()
               .withRootField("continuation", continuationsToken)
               .toJsonString();
       StringEntity payload = new StringEntity(clientJson, "UTF-8");

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubePlaylistLoader.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubePlaylistLoader.java
@@ -37,7 +37,7 @@ public class DefaultYoutubePlaylistLoader implements YoutubePlaylistLoader {
                             Function<AudioTrackInfo, AudioTrack> trackFactory) {
     HttpPost post = new HttpPost(BROWSE_URL);
     String clientJson = YoutubeClientConfig.ANDROID_CLIENT.copy()
-            .withRootBrowseId(playlistId)
+            .withRootField("browseId", "VL" + playlistId)
             .toJsonString();
     StringEntity payload = new StringEntity(clientJson, "UTF-8");
     post.setEntity(payload);
@@ -91,7 +91,7 @@ public class DefaultYoutubePlaylistLoader implements YoutubePlaylistLoader {
     while (continuationsToken != null && ++loadCount < pageCount) {
       HttpPost post = new HttpPost(BROWSE_URL);
       String clientJson = YoutubeClientConfig.ANDROID_CLIENT.copy()
-              .withRootContinuation(continuationsToken)
+              .withRootField("continuation", continuationsToken)
               .toJsonString();
       StringEntity payload = new StringEntity(clientJson, "UTF-8");
       post.setEntity(payload);

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeTrackDetailsLoader.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeTrackDetailsLoader.java
@@ -206,6 +206,7 @@ public class DefaultYoutubeTrackDetailsLoader implements YoutubeTrackDetailsLoad
     } else if (infoStatus == InfoStatus.NON_EMBEDDABLE) {
       // Used when age restriction bypass failed, if we have valid auth then most likely this request will be successful
       config = YoutubeClientConfig.ANDROID_CLIENT.copy();//.withClientDefaultScreenParameters()
+      httpInterface.getContext().setAttribute(BaseYoutubeHttpContextFilter.androidClientContext, true);
     } else if (infoStatus == InfoStatus.REQUIRES_LOGIN) {
       // Age restriction bypass
       config = YoutubeClientConfig.TV_EMBEDDED.copy()
@@ -218,6 +219,7 @@ public class DefaultYoutubeTrackDetailsLoader implements YoutubeTrackDetailsLoad
               .withClientScreen("EMBED")
               .withThirdPartyEmbedUrl("https://google.com");
               //.withClientDefaultScreenParameters();
+      httpInterface.getContext().setAttribute(BaseYoutubeHttpContextFilter.androidClientContext, true);
     }
 
     String payload = config.withRootRacyCheckOk(true)

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeTrackDetailsLoader.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeTrackDetailsLoader.java
@@ -205,7 +205,7 @@ public class DefaultYoutubeTrackDetailsLoader implements YoutubeTrackDetailsLoad
       config = YoutubeClientConfig.WEB.copy();//.withClientDefaultScreenParameters()
     } else if (infoStatus == InfoStatus.NON_EMBEDDABLE) {
       // Used when age restriction bypass failed, if we have valid auth then most likely this request will be successful
-      config = YoutubeClientConfig.ANDROID_CLIENT.copy();//.withClientDefaultScreenParameters()
+      config = YoutubeClientConfig.ANDROID.copy();//.withClientDefaultScreenParameters()
       httpInterface.getContext().setAttribute(YoutubeHttpContextFilter.ATTRIBUTE_ANDROID_REQUEST, true);
     } else if (infoStatus == InfoStatus.REQUIRES_LOGIN) {
       // Age restriction bypass

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeTrackDetailsLoader.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeTrackDetailsLoader.java
@@ -228,7 +228,7 @@ public class DefaultYoutubeTrackDetailsLoader implements YoutubeTrackDetailsLoad
             .withPlaybackSignatureTimestamp(playerScriptTimestamp.scriptTimestamp)
             .toJsonString();
 
-    log.info("Loading track info with payload: {}", payload);
+    log.debug("Loading track info with payload: {}", payload);
 
     post.setEntity(new StringEntity(payload, "UTF-8"));
     try (CloseableHttpResponse response = httpInterface.execute(post)) {

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeTrackDetailsLoader.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeTrackDetailsLoader.java
@@ -206,7 +206,7 @@ public class DefaultYoutubeTrackDetailsLoader implements YoutubeTrackDetailsLoad
     } else if (infoStatus == InfoStatus.NON_EMBEDDABLE) {
       // Used when age restriction bypass failed, if we have valid auth then most likely this request will be successful
       config = YoutubeClientConfig.ANDROID_CLIENT.copy();//.withClientDefaultScreenParameters()
-      httpInterface.getContext().setAttribute(BaseYoutubeHttpContextFilter.androidClientContext, true);
+      httpInterface.getContext().setAttribute(YoutubeHttpContextFilter.ATTRIBUTE_ANDROID_REQUEST, true);
     } else if (infoStatus == InfoStatus.REQUIRES_LOGIN) {
       // Age restriction bypass
       config = YoutubeClientConfig.TV_EMBEDDED.copy()
@@ -219,7 +219,7 @@ public class DefaultYoutubeTrackDetailsLoader implements YoutubeTrackDetailsLoad
               .withClientScreen("EMBED")
               .withThirdPartyEmbedUrl("https://google.com");
               //.withClientDefaultScreenParameters();
-      httpInterface.getContext().setAttribute(BaseYoutubeHttpContextFilter.androidClientContext, true);
+      httpInterface.getContext().setAttribute(YoutubeHttpContextFilter.ATTRIBUTE_ANDROID_REQUEST, true);
     }
 
     String payload = config.withRootRacyCheckOk(true)

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeTrackDetailsLoader.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeTrackDetailsLoader.java
@@ -215,11 +215,11 @@ public class DefaultYoutubeTrackDetailsLoader implements YoutubeTrackDetailsLoad
               //.withClientDefaultScreenParameters();
     } else {
       // Default payload from what we start trying to get required data
-      config = YoutubeClientConfig.ANDROID_CLIENT.copy()
-              .withClientField("clientScreen", "EMBED")
-              .withThirdPartyEmbedUrl("https://google.com");
+      config = YoutubeClientConfig.WEB.copy();
+              //.withClientField("clientScreen", "EMBED")
+              //.withThirdPartyEmbedUrl("https://google.com");
               //.withClientDefaultScreenParameters();
-      httpInterface.getContext().setAttribute(YoutubeHttpContextFilter.ATTRIBUTE_ANDROID_REQUEST, true);
+      //httpInterface.getContext().setAttribute(YoutubeHttpContextFilter.ATTRIBUTE_ANDROID_REQUEST, true);
     }
 
     String payload = config.withRootField("racyCheckOk", true)

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeTrackDetailsLoader.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeTrackDetailsLoader.java
@@ -210,21 +210,21 @@ public class DefaultYoutubeTrackDetailsLoader implements YoutubeTrackDetailsLoad
     } else if (infoStatus == InfoStatus.REQUIRES_LOGIN) {
       // Age restriction bypass
       config = YoutubeClientConfig.TV_EMBEDDED.copy()
-              .withClientScreen("EMBED")
+              .withClientField("clientScreen", "EMBED")
               .withThirdPartyEmbedUrl("https://google.com");
               //.withClientDefaultScreenParameters();
     } else {
       // Default payload from what we start trying to get required data
       config = YoutubeClientConfig.ANDROID_CLIENT.copy()
-              .withClientScreen("EMBED")
+              .withClientField("clientScreen", "EMBED")
               .withThirdPartyEmbedUrl("https://google.com");
               //.withClientDefaultScreenParameters();
       httpInterface.getContext().setAttribute(YoutubeHttpContextFilter.ATTRIBUTE_ANDROID_REQUEST, true);
     }
 
-    String payload = config.withRootRacyCheckOk(true)
-            .withRootContentCheckOk(true)
-            .withRootVideoId(videoId)
+    String payload = config.withRootField("racyCheckOk", true)
+            .withRootField("contentCheckOk", true)
+            .withRootField("videoId", videoId)
             .withPlaybackSignatureTimestamp(playerScriptTimestamp.scriptTimestamp)
             .toJsonString();
 

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeTrackDetailsLoader.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeTrackDetailsLoader.java
@@ -29,8 +29,13 @@ public class DefaultYoutubeTrackDetailsLoader implements YoutubeTrackDetailsLoad
 
   @Override
   public YoutubeTrackDetails loadDetails(HttpInterface httpInterface, String videoId, boolean requireFormats, YoutubeAudioSourceManager sourceManager) {
+    return this.loadDetails(httpInterface, videoId, requireFormats, sourceManager, null);
+  }
+
+  @Override
+  public YoutubeTrackDetails loadDetails(HttpInterface httpInterface, String videoId, boolean requireFormats, YoutubeAudioSourceManager sourceManager, YoutubeClientConfig clientOverride) {
     try {
-      return load(httpInterface, videoId, requireFormats, sourceManager);
+      return load(httpInterface, videoId, requireFormats, sourceManager, clientOverride);
     } catch (IOException e) {
       throw ExceptionTools.toRuntimeException(e);
     }
@@ -40,9 +45,10 @@ public class DefaultYoutubeTrackDetailsLoader implements YoutubeTrackDetailsLoad
       HttpInterface httpInterface,
       String videoId,
       boolean requireFormats,
-      YoutubeAudioSourceManager sourceManager
+      YoutubeAudioSourceManager sourceManager,
+      YoutubeClientConfig clientOverride
   ) throws IOException {
-    JsonBrowser mainInfo = loadTrackInfoFromInnertube(httpInterface, videoId, sourceManager, null);
+    JsonBrowser mainInfo = loadTrackInfoFromInnertube(httpInterface, videoId, sourceManager, null, clientOverride);
 
     try {
       YoutubeTrackJsonData initialData = loadBaseResponse(mainInfo, httpInterface, videoId, sourceManager);
@@ -74,7 +80,7 @@ public class DefaultYoutubeTrackDetailsLoader implements YoutubeTrackDetailsLoad
     }
 
     if (status == InfoStatus.PREMIERE_TRAILER) {
-      JsonBrowser trackInfo = loadTrackInfoFromInnertube(httpInterface, videoId, sourceManager, status);
+      JsonBrowser trackInfo = loadTrackInfoFromInnertube(httpInterface, videoId, sourceManager, status, null);
       data = YoutubeTrackJsonData.fromMainResult(trackInfo
           .get("playabilityStatus")
           .get("errorScreen")
@@ -85,13 +91,13 @@ public class DefaultYoutubeTrackDetailsLoader implements YoutubeTrackDetailsLoad
     }
 
     if (status == InfoStatus.REQUIRES_LOGIN) {
-      JsonBrowser trackInfo = loadTrackInfoFromInnertube(httpInterface, videoId, sourceManager, status);
+      JsonBrowser trackInfo = loadTrackInfoFromInnertube(httpInterface, videoId, sourceManager, status, null);
       data = YoutubeTrackJsonData.fromMainResult(trackInfo);
       status = checkPlayabilityStatus(data.playerResponse, true);
     }
 
     if (status == InfoStatus.NON_EMBEDDABLE) {
-      JsonBrowser trackInfo = loadTrackInfoFromInnertube(httpInterface, videoId, sourceManager, status);
+      JsonBrowser trackInfo = loadTrackInfoFromInnertube(httpInterface, videoId, sourceManager, status, null);
       data = YoutubeTrackJsonData.fromMainResult(trackInfo);
       checkPlayabilityStatus(data.playerResponse, true);
     }
@@ -189,7 +195,8 @@ public class DefaultYoutubeTrackDetailsLoader implements YoutubeTrackDetailsLoad
       HttpInterface httpInterface,
       String videoId,
       YoutubeAudioSourceManager sourceManager,
-      InfoStatus infoStatus
+      InfoStatus infoStatus,
+      YoutubeClientConfig clientOverride
   ) throws IOException {
     if (cachedPlayerScript == null) fetchScript(videoId, httpInterface);
 
@@ -198,28 +205,35 @@ public class DefaultYoutubeTrackDetailsLoader implements YoutubeTrackDetailsLoad
         cachedPlayerScript.playerScriptUrl
     );
     HttpPost post = new HttpPost(PLAYER_URL);
-    YoutubeClientConfig config;
+    YoutubeClientConfig config = clientOverride;
 
-    if (infoStatus == InfoStatus.PREMIERE_TRAILER) {
-      // Android client gives encoded Base64 response to trailer which is also protobuf so we can't decode it
-      config = YoutubeClientConfig.WEB.copy();//.withClientDefaultScreenParameters()
-    } else if (infoStatus == InfoStatus.NON_EMBEDDABLE) {
-      // Used when age restriction bypass failed, if we have valid auth then most likely this request will be successful
-      config = YoutubeClientConfig.ANDROID.copy();//.withClientDefaultScreenParameters()
-      httpInterface.getContext().setAttribute(YoutubeHttpContextFilter.ATTRIBUTE_ANDROID_REQUEST, true);
-    } else if (infoStatus == InfoStatus.REQUIRES_LOGIN) {
-      // Age restriction bypass
-      config = YoutubeClientConfig.TV_EMBEDDED.copy()
-              .withClientField("clientScreen", "EMBED")
-              .withThirdPartyEmbedUrl("https://google.com");
-              //.withClientDefaultScreenParameters();
-    } else {
-      // Default payload from what we start trying to get required data
-      config = YoutubeClientConfig.WEB.copy();
-              //.withClientField("clientScreen", "EMBED")
-              //.withThirdPartyEmbedUrl("https://google.com");
-              //.withClientDefaultScreenParameters();
-      //httpInterface.getContext().setAttribute(YoutubeHttpContextFilter.ATTRIBUTE_ANDROID_REQUEST, true);
+    if (clientOverride == null) {
+      if (infoStatus == InfoStatus.PREMIERE_TRAILER) {
+        // Android client gives encoded Base64 response to trailer which is also protobuf so we can't decode it
+        config = YoutubeClientConfig.WEB.copy();//.withClientDefaultScreenParameters()
+      } else if (infoStatus == InfoStatus.NON_EMBEDDABLE) {
+        // Used when age restriction bypass failed, if we have valid auth then most likely this request will be successful
+        config = YoutubeClientConfig.ANDROID.copy();//.withClientDefaultScreenParameters()
+      } else if (infoStatus == InfoStatus.REQUIRES_LOGIN) {
+        // Age restriction bypass
+        config = YoutubeClientConfig.TV_EMBEDDED.copy()
+                .withClientField("clientScreen", "EMBED")
+                .withThirdPartyEmbedUrl("https://google.com")
+                .withClientDefaultScreenParameters();
+      } else {
+        // Default payload from what we start trying to get required data
+        config = YoutubeClientConfig.WEB.copy();
+          //.withClientField("clientScreen", "EMBED")
+          //.withThirdPartyEmbedUrl("https://google.com");
+          //.withClientDefaultScreenParameters();
+
+        //httpInterface.getContext().setAttribute(YoutubeHttpContextFilter.ATTRIBUTE_USER_AGENT_SPECIFIED, YoutubeClientConfig.ANDROID.getUserAgent());
+      }
+    }
+
+    String userAgent = config.getUserAgent();
+    if (userAgent != null) {
+      httpInterface.getContext().setAttribute(YoutubeHttpContextFilter.ATTRIBUTE_USER_AGENT_SPECIFIED, config.getUserAgent());
     }
 
     String payload = config.withRootField("racyCheckOk", true)

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAccessTokenTracker.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAccessTokenTracker.java
@@ -87,7 +87,7 @@ public class YoutubeAccessTokenTracker {
     synchronized (tokenLock) {
       if (DataFormatTools.isNullOrEmpty(email) && DataFormatTools.isNullOrEmpty(password)) {
         if (!loggedAgeRestrictionsWarning) {
-          log.warn("YouTube auth tokens can't be retrieved because email and password is not set in YoutubeAudioSourceManager, age restricted videos will throw exceptions.");
+          log.warn("YouTube auth tokens can't be retrieved because email and password is unset in YoutubeAudioSourceManager, age restricted videos may throw exceptions.");
           loggedAgeRestrictionsWarning = true;
         }
         return;
@@ -124,7 +124,7 @@ public class YoutubeAccessTokenTracker {
     synchronized (tokenLock) {
       if (DataFormatTools.isNullOrEmpty(email) && DataFormatTools.isNullOrEmpty(password)) {
         if (!loggedAgeRestrictionsWarning) {
-          log.warn("YouTube auth tokens can't be retrieved because email and password is not set in YoutubeAudioSourceManager, age restricted videos will throw exceptions.");
+          log.warn("YouTube auth tokens can't be retrieved because email and password is unset in YoutubeAudioSourceManager, age restricted videos may throw exceptions.");
           loggedAgeRestrictionsWarning = true;
         }
         return;
@@ -266,7 +266,7 @@ public class YoutubeAccessTokenTracker {
   }
 
   private void createAndroidAccount(HttpInterface httpInterface, JsonBrowser jsonBrowser) throws IOException {
-    log.info("Account " + jsonBrowser.get("email").text() + " don't have Android or YouTube profile, creating new one...");
+    log.info("Account {} doesn't have an Android or YouTube profile, creating new one...", jsonBrowser.get("email").text());
 
     HttpPost post = new HttpPost(CHECKIN_ACCOUNT_URL);
     StringEntity payload = new StringEntity(String.format(TOKEN_PAYLOAD, email, password));
@@ -278,7 +278,7 @@ public class YoutubeAccessTokenTracker {
   }
 
   private String continueUrl(HttpInterface httpInterface, JsonBrowser jsonBrowser) throws IOException {
-    log.warn("Not successful attempt to login into account " + jsonBrowser.get("email").text() + ", trying obtain oauth2 token through continue url...");
+    log.warn("Attempt to login into account {} was unsuccessful, trying obtain oauth2 token through continue url...", jsonBrowser.get("email").text());
 
     HttpPost post = new HttpPost(jsonBrowser.get("continueUrl").text());
     RequestConfig config = RequestConfig.custom().setCookieSpec(CookieSpecs.NETSCAPE).setRedirectsEnabled(true).build();

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioTrack.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioTrack.java
@@ -52,8 +52,7 @@ public class YoutubeAudioTrack extends DelegatedAudioTrack {
       } catch (ForbiddenException e) {
         // note for later: Experiment with setting android client user-agent header.
         // with the recent changes to details loading, gv URLs may now expect the header to be present.
-        if (i > 1 && localExecutor.getPosition() == 0) {
-          // Only retry when not on last attempt, haven't received data, and it's a 403.
+        if (i > 1) {
           log.warn("Received 403 response when attempting to load track. Retrying (attempt {}/{})", (MAX_RETRIES - i) + 1, MAX_RETRIES);
           continue;
         }
@@ -82,6 +81,7 @@ public class YoutubeAudioTrack extends DelegatedAudioTrack {
   }
 
   private void processStatic(LocalAudioTrackExecutor localExecutor, HttpInterface httpInterface, FormatWithUrl format, boolean isFallback) throws Exception {
+    httpInterface.getContext().setAttribute(YoutubeHttpContextFilter.ATTRIBUTE_ANDROID_REQUEST, true);
     try (YoutubePersistentHttpStream stream = new YoutubePersistentHttpStream(httpInterface, format.signedUrl, format.details.getContentLength())) {
       if (format.details.getType().getMimeType().endsWith("/webm")) {
         processDelegate(new MatroskaAudioTrack(trackInfo, stream), localExecutor);

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioTrack.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioTrack.java
@@ -62,7 +62,7 @@ public class YoutubeAudioTrack extends DelegatedAudioTrack {
     }
   }
 
-  private void processInternal(LocalAudioTrackExecutor localExecutor) throws Exception, ForbiddenException {
+  private void processInternal(LocalAudioTrackExecutor localExecutor) throws Exception {
     try (HttpInterface httpInterface = sourceManager.getHttpInterface()) {
       FormatWithUrl format = loadBestFormatWithUrl(httpInterface);
 

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioTrack.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioTrack.java
@@ -30,7 +30,7 @@ import static com.sedmelluq.discord.lavaplayer.tools.Units.CONTENT_LENGTH_UNKNOW
 public class YoutubeAudioTrack extends DelegatedAudioTrack {
   private static final Logger log = LoggerFactory.getLogger(YoutubeAudioTrack.class);
 
-  public static final YoutubeClientConfig[] CLIENT_CONFIG_SEQUENCE = new YoutubeClientConfig[] { YoutubeClientConfig.ANDROID, YoutubeClientConfig.IOS };
+  public static YoutubeClientConfig[] CLIENT_CONFIG_SEQUENCE = new YoutubeClientConfig[] { YoutubeClientConfig.ANDROID, YoutubeClientConfig.IOS };
 
   private final YoutubeAudioSourceManager sourceManager;
 

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioTrack.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioTrack.java
@@ -66,7 +66,9 @@ public class YoutubeAudioTrack extends DelegatedAudioTrack {
 
   private void processStaticWithClientRetry(LocalAudioTrackExecutor localExecutor) throws Exception {
     for (int i = 0; i < CLIENT_CONFIG_SEQUENCE.length; i++) {
+      log.warn("Encountered 403 whilst trying to play {}, retrying with client {}", this.trackInfo.identifier, CLIENT_CONFIG_SEQUENCE[i].getName());
       FormatWithUrl format = loadBestFormatWithUrl(CLIENT_CONFIG_SEQUENCE[i]);
+
       try {
         processStatic(localExecutor, format);
         return;

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioTrack.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioTrack.java
@@ -44,7 +44,7 @@ public class YoutubeAudioTrack extends DelegatedAudioTrack {
 
   @Override
   public void process(LocalAudioTrackExecutor localExecutor) throws Exception {
-    //    httpInterface.getContext().setAttribute(YoutubeHttpContextFilter.ATTRIBUTE_ANDROID_REQUEST, true);
+    //httpInterface.getContext().setAttribute(YoutubeHttpContextFilter.ATTRIBUTE_ANDROID_REQUEST, true);
 
     try (HttpInterface httpInterface = sourceManager.getHttpInterface()) {
       FormatWithUrl format = loadBestFormatWithUrl(httpInterface);
@@ -198,7 +198,7 @@ public class YoutubeAudioTrack extends DelegatedAudioTrack {
         return null;
       }
 
-      String newUrl = signedUrl.replace(hosts[0], hosts[1]);
+      String newUrl = signedUrl.replaceFirst(hosts[0], hosts[1]);
 
       try {
         URI uri = new URI(newUrl);

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioTrack.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioTrack.java
@@ -30,7 +30,7 @@ import static com.sedmelluq.discord.lavaplayer.tools.Units.CONTENT_LENGTH_UNKNOW
 public class YoutubeAudioTrack extends DelegatedAudioTrack {
   private static final Logger log = LoggerFactory.getLogger(YoutubeAudioTrack.class);
 
-  private static final YoutubeClientConfig[] CLIENT_CONFIG_SEQUENCE = new YoutubeClientConfig[] { YoutubeClientConfig.ANDROID, YoutubeClientConfig.IOS };
+  public static final YoutubeClientConfig[] CLIENT_CONFIG_SEQUENCE = new YoutubeClientConfig[] { YoutubeClientConfig.ANDROID, YoutubeClientConfig.IOS };
 
   private final YoutubeAudioSourceManager sourceManager;
 

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioTrack.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioTrack.java
@@ -47,6 +47,8 @@ public class YoutubeAudioTrack extends DelegatedAudioTrack {
       try {
         processInternal(localExecutor);
       } catch (ForbiddenException e) {
+        // note for later: Experiment with setting android client user-agent header.
+        // with the recent changes to details loading, gv URLs may now expect the header to be present.
         if (i > 1 && localExecutor.getPosition() == 0) {
           // Only retry when not on last attempt, haven't received data, and it's a 403.
           log.warn("Received 403 response when attempting to load track. Retrying (attempt {}/{})", (MAX_RETRIES - i) + 1, MAX_RETRIES);

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeClientConfig.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeClientConfig.java
@@ -16,7 +16,7 @@ public class YoutubeClientConfig {
             // if needed. This allows users to also override the user agent string which is used by the YoutubeHttpContextFilter.
             // Android %s; US)
             .withUserAgent(String.format("com.google.android.youtube/%s (Linux; U; Android %s) gzip", ANDROID_CLIENT_VERSION, DEFAULT_ANDROID_VERSION.getOsVersion()))
-            .withClientField("clientName", "ANDROID")
+            .withClientName("ANDROID")
             .withClientField("clientVersion", ANDROID_CLIENT_VERSION)
             .withClientField("androidSdkVersion", DEFAULT_ANDROID_VERSION.getSdkVersion())
             .withClientField("osName", "Android")
@@ -28,7 +28,7 @@ public class YoutubeClientConfig {
 
     public static YoutubeClientConfig IOS = new YoutubeClientConfig()
             .withUserAgent("com.google.ios.youtube/17.31.4 (iPhone14,5; U; CPU iOS 15_6 like Mac OS X)")
-            .withClientField("clientName", "IOS")
+            .withClientName("IOS")
             .withClientField("clientVersion", "17.31.4")
             .withClientField("deviceMake", "Apple")
             .withClientField("deviceModel", "iPhone14,5")
@@ -40,21 +40,23 @@ public class YoutubeClientConfig {
 //            .withUserField("lockedSafetyMode", false)
 
     public static YoutubeClientConfig TV_EMBEDDED = new YoutubeClientConfig()
-            .withClientField("clientName", "TVHTML5_SIMPLY_EMBEDDED_PLAYER")
+            .withClientName("TVHTML5_SIMPLY_EMBEDDED_PLAYER")
             .withClientField("clientVersion", "2.0");
             // platform TV
 
     public static YoutubeClientConfig WEB = new YoutubeClientConfig()
-            .withClientField("clientName", "WEB")
+            .withClientName("WEB")
             .withClientField("clientVersion", "2.20220801.00.00");
             // platform DESKTOP
 
     public static YoutubeClientConfig MUSIC = new YoutubeClientConfig()
-            .withClientField("clientName", "WEB_REMIX")
+            .withClientName("WEB_REMIX")
             .withClientField("clientVersion", "1.20220727.01.00");
 
     // root.cpn => content playback nonce, a-zA-Z0-9-_ (16 characters)
     // contextPlaybackContext.refer => url (video watch URL?)
+
+    private String name;
 
     private String userAgent;
 
@@ -63,15 +65,27 @@ public class YoutubeClientConfig {
     public YoutubeClientConfig() {
         this.root = new HashMap<>();
         this.userAgent = null;
+        this.name = null;
     }
 
-    private YoutubeClientConfig(Map<String, Object> context, String userAgent) {
+    private YoutubeClientConfig(Map<String, Object> context, String userAgent, String name) {
         this.root = context;
         this.userAgent = userAgent;
+        this.name = name;
     }
 
     public YoutubeClientConfig copy() {
-        return new YoutubeClientConfig(new HashMap<>(root), userAgent);
+        return new YoutubeClientConfig(new HashMap<>(this.root), this.userAgent, this.name);
+    }
+
+    public YoutubeClientConfig withClientName(String name) {
+        this.name = name;
+        withClientField("clientName", name);
+        return this;
+    }
+
+    public String getName() {
+        return this.name;
     }
 
     public YoutubeClientConfig withUserAgent(String userAgent) {

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeClientConfig.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeClientConfig.java
@@ -8,14 +8,15 @@ import java.util.Map;
 @SuppressWarnings("unchecked")
 public class YoutubeClientConfig {
     public static final String ANDROID_CLIENT_VERSION = "17.39.35";
+    public static final AndroidVersion DEFAULT_ANDROID_VERSION = AndroidVersion.ANDROID_11;
 
     // Clients
     public static YoutubeClientConfig ANDROID_CLIENT = new YoutubeClientConfig()
             .withClientField("clientName", "ANDROID")
             .withClientField("clientVersion", ANDROID_CLIENT_VERSION)
-            .withClientField("androidSdkVersion", 30)
+            .withClientField("androidSdkVersion", DEFAULT_ANDROID_VERSION.getSdkVersion())
             .withClientField("osName", "Android")
-            .withClientField("osVersion", "11");
+            .withClientField("osVersion", DEFAULT_ANDROID_VERSION.osVersion);
             //.withClientField("platform", "MOBILE")
             //.withClientField("hl", "en-GB")
             //.withClientField("gl", "US")
@@ -82,5 +83,28 @@ public class YoutubeClientConfig {
         Map<String, Object> client = (Map<String, Object>) context.computeIfAbsent("client", __ -> new HashMap<String, Object>());
         client.put(key, value);
         return this;
+    }
+
+    public enum AndroidVersion {
+        // https://apilevels.com/
+        ANDROID_13("13", 33),
+        ANDROID_12("12", 31), // 12L => 32
+        ANDROID_11("11", 30);
+
+        private String osVersion;
+        private int sdkVersion;
+
+        AndroidVersion(String osVersion, int sdkVersion) {
+            this.osVersion = osVersion;
+            this.sdkVersion = sdkVersion;
+        }
+
+        public String getOsVersion() {
+            return this.osVersion;
+        }
+
+        public int getSdkVersion() {
+            return this.sdkVersion;
+        }
     }
 }

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeClientConfig.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeClientConfig.java
@@ -19,11 +19,11 @@ public class YoutubeClientConfig {
             .withClientField("clientVersion", ANDROID_CLIENT_VERSION)
             .withClientField("androidSdkVersion", DEFAULT_ANDROID_VERSION.getSdkVersion())
             .withClientField("osName", "Android")
-            .withClientField("osVersion", DEFAULT_ANDROID_VERSION.osVersion)
-            .withClientField("platform", "MOBILE")
-            .withClientField("hl", "en-US")
-            .withClientField("gl", "US")
-            .withUserField("lockedSafetyMode", false);
+            .withClientField("osVersion", DEFAULT_ANDROID_VERSION.osVersion);
+//            .withClientField("platform", "MOBILE")
+//            .withClientField("hl", "en-US")
+//            .withClientField("gl", "US")
+//            .withUserField("lockedSafetyMode", false);
 
     public static YoutubeClientConfig TV_EMBEDDED = new YoutubeClientConfig()
             .withClientField("clientName", "TVHTML5_SIMPLY_EMBEDDED_PLAYER")

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeClientConfig.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeClientConfig.java
@@ -10,11 +10,11 @@ public class YoutubeClientConfig {
     // Clients
     public static YoutubeClientConfig ANDROID_CLIENT = new YoutubeClientConfig()
             .withClientName("ANDROID")
-            .withClientVersion("17.31.35")
+            .withClientVersion("17.39.35") // .31.35
             .withClientAndroidSdkVersion(30)
             .withClientOsName("Android")
             .withClientOsVersion("11")
-            .withClientUserAgent("com.google.android.youtube/17.31.35 (Linux; U; Android 11) gzip");
+            .withClientUserAgent("com.google.android.youtube/17.39.35 (Linux; U; Android 11) gzip");
 
     public static YoutubeClientConfig TV_EMBEDDED = new YoutubeClientConfig()
             .withClientName("TVHTML5_SIMPLY_EMBEDDED_PLAYER")

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeClientConfig.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeClientConfig.java
@@ -13,8 +13,8 @@ public class YoutubeClientConfig {
             .withClientVersion("17.39.35") // .31.35
             .withClientAndroidSdkVersion(30)
             .withClientOsName("Android")
-            .withClientOsVersion("11")
-            .withClientUserAgent("com.google.android.youtube/17.39.35 (Linux; U; Android 11) gzip"); // perhaps this should be set in the headers?
+            .withClientOsVersion("11");
+            //.withClientUserAgent("com.google.android.youtube/17.39.35 (Linux; U; Android 11) gzip"); // perhaps this should be set in the headers?
 
     public static YoutubeClientConfig TV_EMBEDDED = new YoutubeClientConfig()
             .withClientName("TVHTML5_SIMPLY_EMBEDDED_PLAYER")

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeClientConfig.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeClientConfig.java
@@ -11,9 +11,10 @@ public class YoutubeClientConfig {
     public static final AndroidVersion DEFAULT_ANDROID_VERSION = AndroidVersion.ANDROID_11;
 
     // Clients
-    public static YoutubeClientConfig ANDROID_CLIENT = new YoutubeClientConfig()
+    public static YoutubeClientConfig ANDROID = new YoutubeClientConfig()
             // yes this is a weird way of doing it but the logic behind it is that this config can be overwritten by users
             // if needed. This allows users to also override the user agent string which is used by the YoutubeHttpContextFilter.
+            // Android %s; US)
             .withUserAgent(String.format("com.google.android.youtube/%s (Linux; U; Android %s) gzip", ANDROID_CLIENT_VERSION, DEFAULT_ANDROID_VERSION.getOsVersion()))
             .withClientField("clientName", "ANDROID")
             .withClientField("clientVersion", ANDROID_CLIENT_VERSION)
@@ -24,6 +25,19 @@ public class YoutubeClientConfig {
 //            .withClientField("hl", "en-US")
 //            .withClientField("gl", "US")
 //            .withUserField("lockedSafetyMode", false);
+
+    public static YoutubeClientConfig IOS = new YoutubeClientConfig()
+            .withUserAgent("com.google.ios.youtube/17.31.4 (iPhone14,5; U; CPU iOS 15_6 like Mac OS X)")
+            .withClientField("clientName", "IOS")
+            .withClientField("clientVersion", "17.31.4")
+            .withClientField("deviceMake", "Apple")
+            .withClientField("deviceModel", "iPhone14,5")
+            .withClientField("platform", "MOBILE")
+            .withClientField("osName", "iOS")
+            .withClientField("osVersion", "15.6.0.19G71");
+//            .withClientField("hl", "en-US")
+//            .withClientField("gl", "US")
+//            .withUserField("lockedSafetyMode", false)
 
     public static YoutubeClientConfig TV_EMBEDDED = new YoutubeClientConfig()
             .withClientField("clientName", "TVHTML5_SIMPLY_EMBEDDED_PLAYER")

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeClientConfig.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeClientConfig.java
@@ -19,23 +19,28 @@ public class YoutubeClientConfig {
             .withClientField("clientVersion", ANDROID_CLIENT_VERSION)
             .withClientField("androidSdkVersion", DEFAULT_ANDROID_VERSION.getSdkVersion())
             .withClientField("osName", "Android")
-            .withClientField("osVersion", DEFAULT_ANDROID_VERSION.osVersion);
-            //.withClientField("platform", "MOBILE")
-            //.withClientField("hl", "en-GB")
-            //.withClientField("gl", "US")
-            //.withClientUserAgent("com.google.android.youtube/17.39.35 (Linux; U; Android 11) gzip"); // perhaps this should be set in the headers?
+            .withClientField("osVersion", DEFAULT_ANDROID_VERSION.osVersion)
+            .withClientField("platform", "MOBILE")
+            .withClientField("hl", "en-US")
+            .withClientField("gl", "US")
+            .withUserField("lockedSafetyMode", false);
 
     public static YoutubeClientConfig TV_EMBEDDED = new YoutubeClientConfig()
             .withClientField("clientName", "TVHTML5_SIMPLY_EMBEDDED_PLAYER")
             .withClientField("clientVersion", "2.0");
+            // platform TV
 
     public static YoutubeClientConfig WEB = new YoutubeClientConfig()
             .withClientField("clientName", "WEB")
             .withClientField("clientVersion", "2.20220801.00.00");
+            // platform DESKTOP
 
     public static YoutubeClientConfig MUSIC = new YoutubeClientConfig()
             .withClientField("clientName", "WEB_REMIX")
             .withClientField("clientVersion", "1.20220727.01.00");
+
+    // root.cpn => content playback nonce, a-zA-Z0-9-_ (16 characters)
+    // contextPlaybackContext.refer => url (video watch URL?)
 
     private String userAgent;
 
@@ -85,10 +90,6 @@ public class YoutubeClientConfig {
         return this;
     }
 
-    public String toJsonString() {
-        return JsonWriter.string().object(root).done();
-    }
-
     public YoutubeClientConfig withRootField(String key, Object value) {
         root.put(key, value);
         return this;
@@ -99,6 +100,17 @@ public class YoutubeClientConfig {
         Map<String, Object> client = (Map<String, Object>) context.computeIfAbsent("client", __ -> new HashMap<String, Object>());
         client.put(key, value);
         return this;
+    }
+
+    public YoutubeClientConfig withUserField(String key, Object value) {
+        Map<String, Object> context = (Map<String, Object>) root.computeIfAbsent("context", __ -> new HashMap<String, Object>());
+        Map<String, Object> user = (Map<String, Object>) context.computeIfAbsent("user", __ -> new HashMap<String, Object>());
+        user.put(key, value);
+        return this;
+    }
+
+    public String toJsonString() {
+        return JsonWriter.string().object(root).done();
     }
 
     public enum AndroidVersion {

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeClientConfig.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeClientConfig.java
@@ -7,7 +7,7 @@ import java.util.Map;
 
 @SuppressWarnings("unchecked")
 public class YoutubeClientConfig {
-    public static final String ANDROID_CLIENT_VERSION = "17.39.35";
+    public static final String ANDROID_CLIENT_VERSION = "17.36.4"; // 17.39.35
     public static final AndroidVersion DEFAULT_ANDROID_VERSION = AndroidVersion.ANDROID_11;
 
     // Clients
@@ -27,9 +27,9 @@ public class YoutubeClientConfig {
 //            .withUserField("lockedSafetyMode", false);
 
     public static YoutubeClientConfig IOS = new YoutubeClientConfig()
-            .withUserAgent("com.google.ios.youtube/17.31.4 (iPhone14,5; U; CPU iOS 15_6 like Mac OS X)")
+            .withUserAgent("com.google.ios.youtube/17.36.4 (iPhone14,5; U; CPU iOS 15_6 like Mac OS X)")
             .withClientName("IOS")
-            .withClientField("clientVersion", "17.31.4")
+            .withClientField("clientVersion", "17.36.4")
             .withClientField("deviceMake", "Apple")
             .withClientField("deviceModel", "iPhone14,5")
             .withClientField("platform", "MOBILE")

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeClientConfig.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeClientConfig.java
@@ -1,0 +1,122 @@
+package com.sedmelluq.discord.lavaplayer.source.youtube;
+
+import com.grack.nanojson.JsonWriter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@SuppressWarnings("unchecked")
+public class YoutubeClientConfig {
+    // Clients
+    public static YoutubeClientConfig ANDROID_CLIENT = new YoutubeClientConfig()
+            .withClientName("ANDROID")
+            .withClientVersion("17.31.35")
+            .withClientAndroidSdkVersion(30)
+            .withClientOsName("Android")
+            .withClientOsVersion("11")
+            .withClientUserAgent("com.google.android.youtube/17.31.35 (Linux; U; Android 11) gzip");
+
+    public static YoutubeClientConfig TV_EMBEDDED = new YoutubeClientConfig()
+            .withClientName("TVHTML5_SIMPLY_EMBEDDED_PLAYER")
+            .withClientVersion("2.0");
+
+    public static YoutubeClientConfig WEB = new YoutubeClientConfig()
+            .withClientName("WEB")
+            .withClientVersion("2.20220801.00.00");
+
+    // Payloads
+
+    private final Map<String, Object> root;
+
+    public YoutubeClientConfig() {
+        this.root = new HashMap<>();
+    }
+
+    private YoutubeClientConfig(Map<String, Object> context) {
+        this.root = context;
+    }
+
+    public YoutubeClientConfig copy() {
+        return new YoutubeClientConfig(new HashMap<>(root));
+    }
+
+    public YoutubeClientConfig withRootRacyCheckOk(boolean racyCheckOk) {
+        root.put("racyCheckOk", racyCheckOk);
+        return this;
+    }
+
+    public YoutubeClientConfig withRootContentCheckOk(boolean contentCheckOk) {
+        root.put("contentCheckOk", contentCheckOk);
+        return this;
+    }
+
+    public YoutubeClientConfig withRootVideoId(String videoId) {
+        root.put("videoId", videoId);
+        return this;
+    }
+
+    public YoutubeClientConfig withClientName(String clientName) {
+        return putClient("clientName", clientName);
+    }
+
+    public YoutubeClientConfig withClientVersion(String clientVersion) {
+        return putClient("clientVersion", clientVersion);
+    }
+
+    public YoutubeClientConfig withClientAndroidSdkVersion(int androidSdkVersion) {
+        return putClient("androidSdkVersion", androidSdkVersion);
+    }
+
+    public YoutubeClientConfig withClientOsName(String osName) {
+        return putClient("osName", osName);
+    }
+
+    public YoutubeClientConfig withClientOsVersion(String osVersion) {
+        return putClient("osVersion", osVersion);
+    }
+
+    public YoutubeClientConfig withClientUserAgent(String osVersion) {
+        return putClient("osVersion", osVersion);
+    }
+
+    public YoutubeClientConfig withClientScreen(String screen) {
+        return putClient("clientScreen", screen);
+    }
+
+    public YoutubeClientConfig withClientDefaultScreenParameters() {
+        putClient("screenDensityFloat", 1);
+        putClient("screenHeightPoints", 1080);
+        putClient("screenPixelDensity", 1);
+        return putClient("screenWidthPoints", 1920);
+    }
+
+    public YoutubeClientConfig withThirdPartyEmbedUrl(String embedUrl) {
+        Map<String, Object> context = (Map<String, Object>) root.computeIfAbsent("context", __ -> new HashMap<String, Object>());
+        Map<String, Object> thirdParty = (Map<String, Object>) context.computeIfAbsent("thirdParty", __ -> new HashMap<String, Object>());
+        thirdParty.put("embedUrl", embedUrl);
+        return this;
+    }
+
+    public YoutubeClientConfig withPlaybackSignatureTimestamp(String signatureTimestamp) {
+        Map<String, Object> playbackContext = (Map<String, Object>) root.computeIfAbsent("playbackContext", __ -> new HashMap<String, Object>());
+        Map<String, Object> contentPlaybackContext = (Map<String, Object>) playbackContext.computeIfAbsent("contentPlaybackContext", __ -> new HashMap<String, Object>());
+        contentPlaybackContext.put("signatureTimestamp", signatureTimestamp);
+        return this;
+    }
+
+    public String toJsonString() {
+        return JsonWriter.string().object(root).done();
+    }
+
+    private YoutubeClientConfig putRoot(String key, Object value) {
+        root.put(key, value);
+        return this;
+    }
+
+    private YoutubeClientConfig putClient(String key, Object value) {
+        Map<String, Object> context = (Map<String, Object>) root.computeIfAbsent("context", __ -> new HashMap<String, Object>());
+        Map<String, Object> client = (Map<String, Object>) context.computeIfAbsent("client", __ -> new HashMap<String, Object>());
+        client.put(key, value);
+        return this;
+    }
+}

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeClientConfig.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeClientConfig.java
@@ -29,7 +29,7 @@ public class YoutubeClientConfig {
     public static YoutubeClientConfig IOS = new YoutubeClientConfig()
             .withUserAgent("com.google.ios.youtube/17.36.4 (iPhone14,5; U; CPU iOS 15_6 like Mac OS X)")
             .withClientName("IOS")
-            .withClientField("clientVersion", "17.36.4")
+            .withClientField("clientVersion", "17.36.4") // 17.39.4, 17.40.5
             .withClientField("deviceMake", "Apple")
             .withClientField("deviceModel", "iPhone14,5")
             .withClientField("platform", "MOBILE")

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeClientConfig.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeClientConfig.java
@@ -14,7 +14,7 @@ public class YoutubeClientConfig {
             .withClientAndroidSdkVersion(30)
             .withClientOsName("Android")
             .withClientOsVersion("11")
-            .withClientUserAgent("com.google.android.youtube/17.39.35 (Linux; U; Android 11) gzip");
+            .withClientUserAgent("com.google.android.youtube/17.39.35 (Linux; U; Android 11) gzip"); // perhaps this should be set in the headers?
 
     public static YoutubeClientConfig TV_EMBEDDED = new YoutubeClientConfig()
             .withClientName("TVHTML5_SIMPLY_EMBEDDED_PLAYER")

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeClientConfig.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeClientConfig.java
@@ -107,8 +107,8 @@ public class YoutubeClientConfig {
         ANDROID_12("12", 31), // 12L => 32
         ANDROID_11("11", 30);
 
-        private String osVersion;
-        private int sdkVersion;
+        private final String osVersion;
+        private final int sdkVersion;
 
         AndroidVersion(String osVersion, int sdkVersion) {
             this.osVersion = osVersion;

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeClientConfig.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeClientConfig.java
@@ -24,7 +24,11 @@ public class YoutubeClientConfig {
             .withClientName("WEB")
             .withClientVersion("2.20220801.00.00");
 
-    // Payloads
+    public static YoutubeClientConfig MUSIC = new YoutubeClientConfig()
+            .withClientName("WEB_REMIX")
+            .withClientVersion("1.20220727.01.00");
+
+    // TODO: Maybe I should avoid creating a function per key-value and use a generic method?
 
     private final Map<String, Object> root;
 
@@ -55,6 +59,36 @@ public class YoutubeClientConfig {
         return this;
     }
 
+    public YoutubeClientConfig withRootPlaylistId(String playlistId) {
+        root.put("playlistId", playlistId);
+        return this;
+    }
+
+    public YoutubeClientConfig withRootQuery(String query) {
+        root.put("query", query);
+        return this;
+    }
+
+    public YoutubeClientConfig withRootParams(String params) {
+        root.put("params", params);
+        return this;
+    }
+
+    public YoutubeClientConfig withRootBrowseId(String browseId) {
+        root.put("browseId", "VL" + browseId);
+        return this;
+    }
+
+    public YoutubeClientConfig withRootContinuation(String continuation) {
+        root.put("continuation", continuation);
+        return this;
+    }
+
+    public YoutubeClientConfig withRoot(String key, Object value) {
+        root.put(key, value);
+        return this;
+    }
+
     public YoutubeClientConfig withClientName(String clientName) {
         return putClient("clientName", clientName);
     }
@@ -81,6 +115,10 @@ public class YoutubeClientConfig {
 
     public YoutubeClientConfig withClientScreen(String screen) {
         return putClient("clientScreen", screen);
+    }
+
+    public YoutubeClientConfig withClient(String key, Object value) {
+        return putClient(key, value);
     }
 
     public YoutubeClientConfig withClientDefaultScreenParameters() {

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeClientConfig.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeClientConfig.java
@@ -20,7 +20,7 @@ public class YoutubeClientConfig {
             .withClientField("clientVersion", ANDROID_CLIENT_VERSION)
             .withClientField("androidSdkVersion", DEFAULT_ANDROID_VERSION.getSdkVersion())
             .withClientField("osName", "Android")
-            .withClientField("osVersion", DEFAULT_ANDROID_VERSION.osVersion);
+            .withClientField("osVersion", DEFAULT_ANDROID_VERSION.getOsVersion());
 //            .withClientField("platform", "MOBILE")
 //            .withClientField("hl", "en-US")
 //            .withClientField("gl", "US")

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeClientConfig.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeClientConfig.java
@@ -7,32 +7,31 @@ import java.util.Map;
 
 @SuppressWarnings("unchecked")
 public class YoutubeClientConfig {
+    public static final String ANDROID_CLIENT_VERSION = "17.39.35";
+
     // Clients
     public static YoutubeClientConfig ANDROID_CLIENT = new YoutubeClientConfig()
-            .withClientName("ANDROID")
-            .withClientVersion("17.39.35") // .31.35
-            .withClientAndroidSdkVersion(30)
-            .withClientOsName("Android")
-            .withClientOsVersion("11")
-            .withClient("platform", "MOBILE");
-            // PLATFORM = MOBILE
-            // hl = en-GB
-            // gl = US
+            .withClientField("clientName", "ANDROID")
+            .withClientField("clientVersion", ANDROID_CLIENT_VERSION)
+            .withClientField("androidSdkVersion", 30)
+            .withClientField("osName", "Android")
+            .withClientField("osVersion", "11");
+            //.withClientField("platform", "MOBILE")
+            //.withClientField("hl", "en-GB")
+            //.withClientField("gl", "US")
             //.withClientUserAgent("com.google.android.youtube/17.39.35 (Linux; U; Android 11) gzip"); // perhaps this should be set in the headers?
 
     public static YoutubeClientConfig TV_EMBEDDED = new YoutubeClientConfig()
-            .withClientName("TVHTML5_SIMPLY_EMBEDDED_PLAYER")
-            .withClientVersion("2.0");
+            .withClientField("clientName", "TVHTML5_SIMPLY_EMBEDDED_PLAYER")
+            .withClientField("clientVersion", "2.0");
 
     public static YoutubeClientConfig WEB = new YoutubeClientConfig()
-            .withClientName("WEB")
-            .withClientVersion("2.20220801.00.00");
+            .withClientField("clientName", "WEB")
+            .withClientField("clientVersion", "2.20220801.00.00");
 
     public static YoutubeClientConfig MUSIC = new YoutubeClientConfig()
-            .withClientName("WEB_REMIX")
-            .withClientVersion("1.20220727.01.00");
-
-    // TODO: Maybe I should avoid creating a function per key-value and use a generic method?
+            .withClientField("clientName", "WEB_REMIX")
+            .withClientField("clientVersion", "1.20220727.01.00");
 
     private final Map<String, Object> root;
 
@@ -48,88 +47,11 @@ public class YoutubeClientConfig {
         return new YoutubeClientConfig(new HashMap<>(root));
     }
 
-    public YoutubeClientConfig withRootRacyCheckOk(boolean racyCheckOk) {
-        root.put("racyCheckOk", racyCheckOk);
-        return this;
-    }
-
-    public YoutubeClientConfig withRootContentCheckOk(boolean contentCheckOk) {
-        root.put("contentCheckOk", contentCheckOk);
-        return this;
-    }
-
-    public YoutubeClientConfig withRootVideoId(String videoId) {
-        root.put("videoId", videoId);
-        return this;
-    }
-
-    public YoutubeClientConfig withRootPlaylistId(String playlistId) {
-        root.put("playlistId", playlistId);
-        return this;
-    }
-
-    public YoutubeClientConfig withRootQuery(String query) {
-        root.put("query", query);
-        return this;
-    }
-
-    public YoutubeClientConfig withRootParams(String params) {
-        root.put("params", params);
-        return this;
-    }
-
-    public YoutubeClientConfig withRootBrowseId(String browseId) {
-        root.put("browseId", "VL" + browseId);
-        return this;
-    }
-
-    public YoutubeClientConfig withRootContinuation(String continuation) {
-        root.put("continuation", continuation);
-        return this;
-    }
-
-    public YoutubeClientConfig withRoot(String key, Object value) {
-        root.put(key, value);
-        return this;
-    }
-
-    public YoutubeClientConfig withClientName(String clientName) {
-        return putClient("clientName", clientName);
-    }
-
-    public YoutubeClientConfig withClientVersion(String clientVersion) {
-        return putClient("clientVersion", clientVersion);
-    }
-
-    public YoutubeClientConfig withClientAndroidSdkVersion(int androidSdkVersion) {
-        return putClient("androidSdkVersion", androidSdkVersion);
-    }
-
-    public YoutubeClientConfig withClientOsName(String osName) {
-        return putClient("osName", osName);
-    }
-
-    public YoutubeClientConfig withClientOsVersion(String osVersion) {
-        return putClient("osVersion", osVersion);
-    }
-
-    public YoutubeClientConfig withClientUserAgent(String osVersion) {
-        return putClient("osVersion", osVersion);
-    }
-
-    public YoutubeClientConfig withClientScreen(String screen) {
-        return putClient("clientScreen", screen);
-    }
-
-    public YoutubeClientConfig withClient(String key, Object value) {
-        return putClient(key, value);
-    }
-
     public YoutubeClientConfig withClientDefaultScreenParameters() {
-        putClient("screenDensityFloat", 1);
-        putClient("screenHeightPoints", 1080);
-        putClient("screenPixelDensity", 1);
-        return putClient("screenWidthPoints", 1920);
+        withClientField("screenDensityFloat", 1);
+        withClientField("screenHeightPoints", 1080);
+        withClientField("screenPixelDensity", 1);
+        return withClientField("screenWidthPoints", 1920);
     }
 
     public YoutubeClientConfig withThirdPartyEmbedUrl(String embedUrl) {
@@ -150,12 +72,12 @@ public class YoutubeClientConfig {
         return JsonWriter.string().object(root).done();
     }
 
-    private YoutubeClientConfig putRoot(String key, Object value) {
+    public YoutubeClientConfig withRootField(String key, Object value) {
         root.put(key, value);
         return this;
     }
 
-    private YoutubeClientConfig putClient(String key, Object value) {
+    public YoutubeClientConfig withClientField(String key, Object value) {
         Map<String, Object> context = (Map<String, Object>) root.computeIfAbsent("context", __ -> new HashMap<String, Object>());
         Map<String, Object> client = (Map<String, Object>) context.computeIfAbsent("client", __ -> new HashMap<String, Object>());
         client.put(key, value);

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeClientConfig.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeClientConfig.java
@@ -13,7 +13,11 @@ public class YoutubeClientConfig {
             .withClientVersion("17.39.35") // .31.35
             .withClientAndroidSdkVersion(30)
             .withClientOsName("Android")
-            .withClientOsVersion("11");
+            .withClientOsVersion("11")
+            .withClient("platform", "MOBILE");
+            // PLATFORM = MOBILE
+            // hl = en-GB
+            // gl = US
             //.withClientUserAgent("com.google.android.youtube/17.39.35 (Linux; U; Android 11) gzip"); // perhaps this should be set in the headers?
 
     public static YoutubeClientConfig TV_EMBEDDED = new YoutubeClientConfig()

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeClientConfig.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeClientConfig.java
@@ -12,6 +12,9 @@ public class YoutubeClientConfig {
 
     // Clients
     public static YoutubeClientConfig ANDROID_CLIENT = new YoutubeClientConfig()
+            // yes this is a weird way of doing it but the logic behind it is that this config can be overwritten by users
+            // if needed. This allows users to also override the user agent string which is used by the YoutubeHttpContextFilter.
+            .withUserAgent(String.format("com.google.android.youtube/%s (Linux; U; Android %s) gzip", ANDROID_CLIENT_VERSION, DEFAULT_ANDROID_VERSION.getOsVersion()))
             .withClientField("clientName", "ANDROID")
             .withClientField("clientVersion", ANDROID_CLIENT_VERSION)
             .withClientField("androidSdkVersion", DEFAULT_ANDROID_VERSION.getSdkVersion())
@@ -34,18 +37,31 @@ public class YoutubeClientConfig {
             .withClientField("clientName", "WEB_REMIX")
             .withClientField("clientVersion", "1.20220727.01.00");
 
+    private String userAgent;
+
     private final Map<String, Object> root;
 
     public YoutubeClientConfig() {
         this.root = new HashMap<>();
+        this.userAgent = null;
     }
 
-    private YoutubeClientConfig(Map<String, Object> context) {
+    private YoutubeClientConfig(Map<String, Object> context, String userAgent) {
         this.root = context;
+        this.userAgent = userAgent;
     }
 
     public YoutubeClientConfig copy() {
-        return new YoutubeClientConfig(new HashMap<>(root));
+        return new YoutubeClientConfig(new HashMap<>(root), userAgent);
+    }
+
+    public YoutubeClientConfig withUserAgent(String userAgent) {
+        this.userAgent = userAgent;
+        return this;
+    }
+
+    public String getUserAgent() {
+        return this.userAgent;
     }
 
     public YoutubeClientConfig withClientDefaultScreenParameters() {

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeConstants.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeConstants.java
@@ -15,7 +15,7 @@ public class YoutubeConstants {
     static final String CLIENT_TVHTML5_NAME = "TVHTML5_SIMPLY_EMBEDDED_PLAYER";
     static final String CLIENT_TVHTML5_VERSION = "2.0";
     static final String CLIENT_SCREEN_EMBED = "EMBED";
-    static final String BASE_PAYLOAD = "{\"context\":{\"client\":{\"clientName\":\"%s\",\"clientVersion\":\"%s\",\"osName\":\"Android\",\"osVersion\":\"12\",\"userAgent\":\"com.google.android.youtube/17.31.35 (Linux; U; Android 12) gzip\"";
+    static final String BASE_PAYLOAD = "{\"context\":{\"client\":{\"clientName\":\"%s\",\"clientVersion\":\"%s\",\"osName\":\"Android\",\"osVersion\":\"11\",\"userAgent\":\"com.google.android.youtube/17.31.35 (Linux; U; Android 11) gzip\"";
     static final String SDK_VERSION_PART_BASE_PAYLOAD = ",\"androidSdkVersion\":" + CLIENT_ANDROID_SDK_VERSION;
     static final String DEFAULT_BASE_PAYLOAD = String.format(BASE_PAYLOAD, CLIENT_ANDROID_NAME, CLIENT_ANDROID_VERSION) + SDK_VERSION_PART_BASE_PAYLOAD;
     static final String SCREEN_PART_PAYLOAD = ",\"screenDensityFloat\":1,\"screenHeightPoints\":1080,\"screenPixelDensity\":1,\"screenWidthPoints\":1920";

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeConstants.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeConstants.java
@@ -10,24 +10,15 @@ public class YoutubeConstants {
     static final String CLIENT_ANDROID_NAME = "ANDROID";
     static final String CLIENT_ANDROID_VERSION = "17.31.35";
     static final String CLIENT_ANDROID_SDK_VERSION = "30";
-    static final String CLIENT_WEB_NAME = "WEB";
-    static final String CLIENT_WEB_VERSION = "2.20220801.00.00";
-    static final String CLIENT_TVHTML5_NAME = "TVHTML5_SIMPLY_EMBEDDED_PLAYER";
-    static final String CLIENT_TVHTML5_VERSION = "2.0";
-    static final String CLIENT_SCREEN_EMBED = "EMBED";
     static final String BASE_PAYLOAD = "{\"context\":{\"client\":{\"clientName\":\"%s\",\"clientVersion\":\"%s\",\"osName\":\"Android\",\"osVersion\":\"11\",\"userAgent\":\"com.google.android.youtube/17.31.35 (Linux; U; Android 11) gzip\"";
     static final String SDK_VERSION_PART_BASE_PAYLOAD = ",\"androidSdkVersion\":" + CLIENT_ANDROID_SDK_VERSION;
     static final String DEFAULT_BASE_PAYLOAD = String.format(BASE_PAYLOAD, CLIENT_ANDROID_NAME, CLIENT_ANDROID_VERSION) + SDK_VERSION_PART_BASE_PAYLOAD;
     static final String SCREEN_PART_PAYLOAD = ",\"screenDensityFloat\":1,\"screenHeightPoints\":1080,\"screenPixelDensity\":1,\"screenWidthPoints\":1920";
-    static final String EMBED_PART_PAYLOAD = ",\"clientScreen\":\"" + CLIENT_SCREEN_EMBED + "\"},\"thirdParty\":{\"embedUrl\":\"https://google.com\"";
     static final String CLOSE_BASE_PAYLOAD = "}},";
-    static final String CLOSE_PLAYER_PAYLOAD = "\"racyCheckOk\":true,\"contentCheckOk\":true,\"videoId\":\"%s\",\"playbackContext\":{\"contentPlaybackContext\":{\"signatureTimestamp\":%s}}}";
 
     static final String SEARCH_URL = BASE_URL + "/search?key=" + INNERTUBE_API_KEY;
     static final String SEARCH_PAYLOAD = DEFAULT_BASE_PAYLOAD + SCREEN_PART_PAYLOAD + CLOSE_BASE_PAYLOAD + "\"query\":\"%s\",\"params\":\"EgIQAQ==\"}";
     static final String PLAYER_URL = BASE_URL + "/player";
-    static final String PLAYER_PAYLOAD = DEFAULT_BASE_PAYLOAD + SCREEN_PART_PAYLOAD + CLOSE_BASE_PAYLOAD + CLOSE_PLAYER_PAYLOAD;
-    static final String PLAYER_EMBED_PAYLOAD = DEFAULT_BASE_PAYLOAD + SCREEN_PART_PAYLOAD + EMBED_PART_PAYLOAD + CLOSE_BASE_PAYLOAD + CLOSE_PLAYER_PAYLOAD;
     static final String BROWSE_URL = BASE_URL + "/browse";
     static final String BROWSE_PLAYLIST_PAYLOAD = DEFAULT_BASE_PAYLOAD + SCREEN_PART_PAYLOAD + CLOSE_BASE_PAYLOAD + "\"browseId\":\"VL%s\"}";
     static final String BROWSE_CONTINUATION_PAYLOAD = DEFAULT_BASE_PAYLOAD + SCREEN_PART_PAYLOAD + CLOSE_BASE_PAYLOAD + "\"continuation\":\"%s\"}";

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeConstants.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeConstants.java
@@ -15,7 +15,7 @@ public class YoutubeConstants {
     static final String CLIENT_TVHTML5_NAME = "TVHTML5_SIMPLY_EMBEDDED_PLAYER";
     static final String CLIENT_TVHTML5_VERSION = "2.0";
     static final String CLIENT_SCREEN_EMBED = "EMBED";
-    static final String BASE_PAYLOAD = "{\"context\":{\"client\":{\"clientName\":\"%s\",\"clientVersion\":\"%s\",\"osName\":\"Android\",\"osVersion\":\"12\",\"userAgent\":\"com.google.android.youtube/17.31.35 (Linux; U; Android 11) gzip\"";
+    static final String BASE_PAYLOAD = "{\"context\":{\"client\":{\"clientName\":\"%s\",\"clientVersion\":\"%s\",\"osName\":\"Android\",\"osVersion\":\"12\",\"userAgent\":\"com.google.android.youtube/17.31.35 (Linux; U; Android 12) gzip\"";
     static final String SDK_VERSION_PART_BASE_PAYLOAD = ",\"androidSdkVersion\":" + CLIENT_ANDROID_SDK_VERSION;
     static final String DEFAULT_BASE_PAYLOAD = String.format(BASE_PAYLOAD, CLIENT_ANDROID_NAME, CLIENT_ANDROID_VERSION) + SDK_VERSION_PART_BASE_PAYLOAD;
     static final String SCREEN_PART_PAYLOAD = ",\"screenDensityFloat\":1,\"screenHeightPoints\":1080,\"screenPixelDensity\":1,\"screenWidthPoints\":1920";

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeConstants.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeConstants.java
@@ -15,7 +15,7 @@ public class YoutubeConstants {
     static final String CLIENT_TVHTML5_NAME = "TVHTML5_SIMPLY_EMBEDDED_PLAYER";
     static final String CLIENT_TVHTML5_VERSION = "2.0";
     static final String CLIENT_SCREEN_EMBED = "EMBED";
-    static final String BASE_PAYLOAD = "{\"context\":{\"client\":{\"clientName\":\"%s\",\"clientVersion\":\"%s\"";
+    static final String BASE_PAYLOAD = "{\"context\":{\"client\":{\"clientName\":\"%s\",\"clientVersion\":\"%s\",\"osName\":\"Android\",\"osVersion\":\"12\",\"userAgent\":\"com.google.android.youtube/17.31.35 (Linux; U; Android 11) gzip\"";
     static final String SDK_VERSION_PART_BASE_PAYLOAD = ",\"androidSdkVersion\":" + CLIENT_ANDROID_SDK_VERSION;
     static final String DEFAULT_BASE_PAYLOAD = String.format(BASE_PAYLOAD, CLIENT_ANDROID_NAME, CLIENT_ANDROID_VERSION) + SDK_VERSION_PART_BASE_PAYLOAD;
     static final String SCREEN_PART_PAYLOAD = ",\"screenDensityFloat\":1,\"screenHeightPoints\":1080,\"screenPixelDensity\":1,\"screenWidthPoints\":1920";

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeConstants.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeConstants.java
@@ -7,33 +7,16 @@ public class YoutubeConstants {
     static final String YOUTUBE_API_ORIGIN = "https://youtubei.googleapis.com";
     static final String BASE_URL = YOUTUBE_API_ORIGIN + "/youtubei/v1";
     static final String INNERTUBE_API_KEY = "AIzaSyA8eiZmM1FaDVjRy-df2KTyQ_vz_yYM39w";
-    static final String CLIENT_ANDROID_NAME = "ANDROID";
-    static final String CLIENT_ANDROID_VERSION = "17.31.35";
-    static final String CLIENT_ANDROID_SDK_VERSION = "30";
-    static final String BASE_PAYLOAD = "{\"context\":{\"client\":{\"clientName\":\"%s\",\"clientVersion\":\"%s\",\"osName\":\"Android\",\"osVersion\":\"11\",\"userAgent\":\"com.google.android.youtube/17.31.35 (Linux; U; Android 11) gzip\"";
-    static final String SDK_VERSION_PART_BASE_PAYLOAD = ",\"androidSdkVersion\":" + CLIENT_ANDROID_SDK_VERSION;
-    static final String DEFAULT_BASE_PAYLOAD = String.format(BASE_PAYLOAD, CLIENT_ANDROID_NAME, CLIENT_ANDROID_VERSION) + SDK_VERSION_PART_BASE_PAYLOAD;
-    static final String SCREEN_PART_PAYLOAD = ",\"screenDensityFloat\":1,\"screenHeightPoints\":1080,\"screenPixelDensity\":1,\"screenWidthPoints\":1920";
-    static final String CLOSE_BASE_PAYLOAD = "}},";
 
     static final String SEARCH_URL = BASE_URL + "/search?key=" + INNERTUBE_API_KEY;
-    static final String SEARCH_PAYLOAD = DEFAULT_BASE_PAYLOAD + SCREEN_PART_PAYLOAD + CLOSE_BASE_PAYLOAD + "\"query\":\"%s\",\"params\":\"EgIQAQ==\"}";
     static final String PLAYER_URL = BASE_URL + "/player";
     static final String BROWSE_URL = BASE_URL + "/browse";
-    static final String BROWSE_PLAYLIST_PAYLOAD = DEFAULT_BASE_PAYLOAD + SCREEN_PART_PAYLOAD + CLOSE_BASE_PAYLOAD + "\"browseId\":\"VL%s\"}";
-    static final String BROWSE_CONTINUATION_PAYLOAD = DEFAULT_BASE_PAYLOAD + SCREEN_PART_PAYLOAD + CLOSE_BASE_PAYLOAD + "\"continuation\":\"%s\"}";
     static final String NEXT_URL = BASE_URL + "/next";
-    static final String NEXT_PAYLOAD = DEFAULT_BASE_PAYLOAD + SCREEN_PART_PAYLOAD + CLOSE_BASE_PAYLOAD + "\"videoId\":\"%s\",\"playlistId\":\"%s\"}";
 
     // YouTube Music constants
     static final String MUSIC_BASE_URL = "https://music.youtube.com/youtubei/v1";
     static final String MUSIC_INNERTUBE_API_KEY = "AIzaSyC9XL3ZjWddXya6X74dJoCTL-WEYFDNX30";
-    static final String MUSIC_CLIENT_NAME = "WEB_REMIX";
-    static final String MUSIC_CLIENT_VERSION = "1.20220727.01.00"; // 0.1
-    static final String MUSIC_BASE_PAYLOAD = "{\"context\":{\"client\":{\"clientName\":\"" + MUSIC_CLIENT_NAME + "\",\"clientVersion\":\"" + MUSIC_CLIENT_VERSION + "\"}},";
-
     static final String MUSIC_SEARCH_URL = MUSIC_BASE_URL + "/search?key=" + MUSIC_INNERTUBE_API_KEY;
-    static final String MUSIC_SEARCH_PAYLOAD = MUSIC_BASE_PAYLOAD + "\"query\":\"%s\",\"params\":\"Eg-KAQwIARAAGAAgACgAMABqChADEAQQCRAFEAo=\"}";
 
     // YouTube TV auth constants
     static final String TV_AUTH_BASE_URL = YOUTUBE_ORIGIN + "/o/oauth2";

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeConstants.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeConstants.java
@@ -8,7 +8,7 @@ public class YoutubeConstants {
     static final String BASE_URL = YOUTUBE_API_ORIGIN + "/youtubei/v1";
     static final String INNERTUBE_API_KEY = "AIzaSyA8eiZmM1FaDVjRy-df2KTyQ_vz_yYM39w";
     static final String CLIENT_ANDROID_NAME = "ANDROID";
-    static final String CLIENT_ANDROID_VERSION = "17.29.34";
+    static final String CLIENT_ANDROID_VERSION = "17.31.35";
     static final String CLIENT_ANDROID_SDK_VERSION = "30";
     static final String CLIENT_WEB_NAME = "WEB";
     static final String CLIENT_WEB_VERSION = "2.20220801.00.00";
@@ -38,7 +38,7 @@ public class YoutubeConstants {
     static final String MUSIC_BASE_URL = "https://music.youtube.com/youtubei/v1";
     static final String MUSIC_INNERTUBE_API_KEY = "AIzaSyC9XL3ZjWddXya6X74dJoCTL-WEYFDNX30";
     static final String MUSIC_CLIENT_NAME = "WEB_REMIX";
-    static final String MUSIC_CLIENT_VERSION = "0.1";
+    static final String MUSIC_CLIENT_VERSION = "1.20220727.01.00"; // 0.1
     static final String MUSIC_BASE_PAYLOAD = "{\"context\":{\"client\":{\"clientName\":\"" + MUSIC_CLIENT_NAME + "\",\"clientVersion\":\"" + MUSIC_CLIENT_VERSION + "\"}},";
 
     static final String MUSIC_SEARCH_URL = MUSIC_BASE_URL + "/search?key=" + MUSIC_INNERTUBE_API_KEY;

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeHttpContextFilter.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeHttpContextFilter.java
@@ -68,7 +68,7 @@ public class YoutubeHttpContextFilter extends BaseYoutubeHttpContextFilter {
 
     if (context.getAttribute(ATTRIBUTE_ANDROID_REQUEST) == Boolean.TRUE) {
       log.debug("Applying android user-agent header.");
-      request.setHeader("user-agent", YoutubeClientConfig.ANDROID_CLIENT.getUserAgent());
+      request.setHeader("user-agent", YoutubeClientConfig.ANDROID.getUserAgent());
       context.removeAttribute(ATTRIBUTE_ANDROID_REQUEST);
     }
 

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeHttpContextFilter.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeHttpContextFilter.java
@@ -21,7 +21,7 @@ import java.net.URISyntaxException;
 import static com.sedmelluq.discord.lavaplayer.tools.FriendlyException.Severity.COMMON;
 
 public class YoutubeHttpContextFilter extends BaseYoutubeHttpContextFilter {
-  private static final Logger log = LoggerFactory.getLogger(BaseYoutubeHttpContextFilter.class);
+  private static final Logger log = LoggerFactory.getLogger(YoutubeHttpContextFilter.class);
 
 
   private static final String ATTRIBUTE_RESET_RETRY = "isResetRetry";
@@ -67,7 +67,7 @@ public class YoutubeHttpContextFilter extends BaseYoutubeHttpContextFilter {
     }
 
     if (context.getAttribute(ATTRIBUTE_ANDROID_REQUEST) == Boolean.TRUE) {
-      log.info("Applying android user-agent header.");
+      log.debug("Applying android user-agent header.");
       request.setHeader("user-agent", YoutubeClientConfig.ANDROID_CLIENT.getUserAgent());
       context.removeAttribute(ATTRIBUTE_ANDROID_REQUEST);
     }

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeHttpContextFilter.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeHttpContextFilter.java
@@ -25,7 +25,7 @@ public class YoutubeHttpContextFilter extends BaseYoutubeHttpContextFilter {
 
 
   private static final String ATTRIBUTE_RESET_RETRY = "isResetRetry";
-  public static final String ATTRIBUTE_ANDROID_REQUEST = "android-client-req";
+  public static final String ATTRIBUTE_USER_AGENT_SPECIFIED = "clientUserAgent";
 
   private static final HttpContextRetryCounter retryCounter = new HttpContextRetryCounter("yt-token-retry");
 
@@ -66,10 +66,11 @@ public class YoutubeHttpContextFilter extends BaseYoutubeHttpContextFilter {
       return;
     }
 
-    if (context.getAttribute(ATTRIBUTE_ANDROID_REQUEST) == Boolean.TRUE) {
-      log.debug("Applying android user-agent header.");
-      request.setHeader("user-agent", YoutubeClientConfig.ANDROID.getUserAgent());
-      context.removeAttribute(ATTRIBUTE_ANDROID_REQUEST);
+    String clientUserAgent = context.getAttribute(ATTRIBUTE_USER_AGENT_SPECIFIED, String.class);
+    if (clientUserAgent != null) {
+      log.debug("Applying user-agent header \"{}\"", clientUserAgent);
+      request.setHeader("user-agent", clientUserAgent);
+      context.removeAttribute(ATTRIBUTE_USER_AGENT_SPECIFIED);
     }
 
     String accessToken = tokenTracker.getAccessToken();

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeHttpContextFilter.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeHttpContextFilter.java
@@ -69,6 +69,7 @@ public class YoutubeHttpContextFilter extends BaseYoutubeHttpContextFilter {
     if (context.getAttribute(ATTRIBUTE_ANDROID_REQUEST) == Boolean.TRUE) {
       log.info("Applying android user-agent header.");
       request.setHeader("user-agent", "com.google.android.youtube/17.39.35 (Linux; U; Android 11) gzip");
+      context.removeAttribute(ATTRIBUTE_RESET_RETRY);
     }
 
     String accessToken = tokenTracker.getAccessToken();

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeHttpContextFilter.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeHttpContextFilter.java
@@ -68,7 +68,7 @@ public class YoutubeHttpContextFilter extends BaseYoutubeHttpContextFilter {
 
     if (context.getAttribute(ATTRIBUTE_ANDROID_REQUEST) == Boolean.TRUE) {
       log.info("Applying android user-agent header.");
-      request.setHeader("user-agent", "com.google.android.youtube/17.39.35 (Linux; U; Android 11) gzip");
+      request.setHeader("user-agent", String.format("com.google.android.youtube/%s (Linux; U; Android %s) gzip", YoutubeClientConfig.ANDROID_CLIENT_VERSION, YoutubeClientConfig.DEFAULT_ANDROID_VERSION.getOsVersion()));
       context.removeAttribute(ATTRIBUTE_ANDROID_REQUEST);
     }
 

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeHttpContextFilter.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeHttpContextFilter.java
@@ -69,7 +69,7 @@ public class YoutubeHttpContextFilter extends BaseYoutubeHttpContextFilter {
     if (context.getAttribute(ATTRIBUTE_ANDROID_REQUEST) == Boolean.TRUE) {
       log.info("Applying android user-agent header.");
       request.setHeader("user-agent", "com.google.android.youtube/17.39.35 (Linux; U; Android 11) gzip");
-      context.removeAttribute(ATTRIBUTE_RESET_RETRY);
+      context.removeAttribute(ATTRIBUTE_ANDROID_REQUEST);
     }
 
     String accessToken = tokenTracker.getAccessToken();

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeHttpContextFilter.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeHttpContextFilter.java
@@ -68,7 +68,7 @@ public class YoutubeHttpContextFilter extends BaseYoutubeHttpContextFilter {
 
     if (context.getAttribute(ATTRIBUTE_ANDROID_REQUEST) == Boolean.TRUE) {
       log.info("Applying android user-agent header.");
-      request.setHeader("user-agent", String.format("com.google.android.youtube/%s (Linux; U; Android %s) gzip", YoutubeClientConfig.ANDROID_CLIENT_VERSION, YoutubeClientConfig.DEFAULT_ANDROID_VERSION.getOsVersion()));
+      request.setHeader("user-agent", YoutubeClientConfig.ANDROID_CLIENT.getUserAgent());
       context.removeAttribute(ATTRIBUTE_ANDROID_REQUEST);
     }
 

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeHttpContextFilter.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeHttpContextFilter.java
@@ -12,6 +12,8 @@ import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.impl.client.BasicCookieStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -19,7 +21,12 @@ import java.net.URISyntaxException;
 import static com.sedmelluq.discord.lavaplayer.tools.FriendlyException.Severity.COMMON;
 
 public class YoutubeHttpContextFilter extends BaseYoutubeHttpContextFilter {
+  private static final Logger log = LoggerFactory.getLogger(BaseYoutubeHttpContextFilter.class);
+
+
   private static final String ATTRIBUTE_RESET_RETRY = "isResetRetry";
+  public static final String ATTRIBUTE_ANDROID_REQUEST = "android-client-req";
+
   private static final HttpContextRetryCounter retryCounter = new HttpContextRetryCounter("yt-token-retry");
 
   private YoutubeAccessTokenTracker tokenTracker;
@@ -57,6 +64,11 @@ public class YoutubeHttpContextFilter extends BaseYoutubeHttpContextFilter {
     if (tokenTracker.isTokenFetchContext(context)) {
       // Used for fetching access token, let's not recurse.
       return;
+    }
+
+    if (context.getAttribute(ATTRIBUTE_ANDROID_REQUEST) == Boolean.TRUE) {
+      log.info("Applying android user-agent header.");
+      request.setHeader("user-agent", "com.google.android.youtube/17.39.35 (Linux; U; Android 11) gzip");
     }
 
     String accessToken = tokenTracker.getAccessToken();

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeMixProvider.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeMixProvider.java
@@ -44,9 +44,8 @@ public class YoutubeMixProvider implements YoutubeMixLoader {
 
     HttpPost post = new HttpPost(NEXT_URL);
     String json = YoutubeClientConfig.ANDROID_CLIENT.copy()
-            .withRootVideoId(selectedVideoId)
-            .withRootPlaylistId(mixId)
-            //.withClientDefaultScreenParameters()
+            .withRootField("videoId", selectedVideoId)
+            .withRootField("playlistId", mixId)
             .toJsonString();
     StringEntity payload = new StringEntity(json, "UTF-8");
     post.setEntity(payload);

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeMixProvider.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeMixProvider.java
@@ -43,7 +43,7 @@ public class YoutubeMixProvider implements YoutubeMixLoader {
     List<AudioTrack> tracks = new ArrayList<>();
 
     HttpPost post = new HttpPost(NEXT_URL);
-    String json = YoutubeClientConfig.ANDROID_CLIENT.copy()
+    String json = YoutubeClientConfig.ANDROID.copy()
             .withRootField("videoId", selectedVideoId)
             .withRootField("playlistId", mixId)
             .toJsonString();

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeMixProvider.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeMixProvider.java
@@ -18,7 +18,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
-import static com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeConstants.NEXT_PAYLOAD;
 import static com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeConstants.NEXT_URL;
 import static com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeConstants.WATCH_URL_PREFIX;
 import static com.sedmelluq.discord.lavaplayer.tools.FriendlyException.Severity.SUSPICIOUS;
@@ -44,7 +43,12 @@ public class YoutubeMixProvider implements YoutubeMixLoader {
     List<AudioTrack> tracks = new ArrayList<>();
 
     HttpPost post = new HttpPost(NEXT_URL);
-    StringEntity payload = new StringEntity(String.format(NEXT_PAYLOAD, selectedVideoId, mixId), "UTF-8");
+    String json = YoutubeClientConfig.ANDROID_CLIENT.copy()
+            .withRootVideoId(selectedVideoId)
+            .withRootPlaylistId(mixId)
+            //.withClientDefaultScreenParameters()
+            .toJsonString();
+    StringEntity payload = new StringEntity(json, "UTF-8");
     post.setEntity(payload);
 
     try (CloseableHttpResponse response = httpInterface.execute(post)) {

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubePersistentHttpStream.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubePersistentHttpStream.java
@@ -1,16 +1,26 @@
 package com.sedmelluq.discord.lavaplayer.source.youtube;
 
+import com.sedmelluq.discord.lavaplayer.tools.io.HttpClientTools;
 import com.sedmelluq.discord.lavaplayer.tools.io.HttpInterface;
 import com.sedmelluq.discord.lavaplayer.tools.io.PersistentHttpStream;
+import org.apache.http.client.utils.URIBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import org.apache.http.client.utils.URIBuilder;
 
 /**
  * A persistent HTTP stream implementation that uses the range parameter instead of HTTP headers for specifying
  * the start position at which to start reading on a new connection.
  */
 public class YoutubePersistentHttpStream extends PersistentHttpStream {
+  private static final Logger log = LoggerFactory.getLogger(YoutubePersistentHttpStream.class);
+
+  private static final long BUFFER_SIZE = 500000;
+
+  private long rangeEnd;
 
   /**
    * @param httpInterface The HTTP interface to use for requests
@@ -23,15 +33,104 @@ public class YoutubePersistentHttpStream extends PersistentHttpStream {
 
   @Override
   protected URI getConnectUrl() {
-    if (position > 0) {
-      try {
-        return new URIBuilder(contentUrl).addParameter("range", position + "-" + contentLength).build();
-      } catch (URISyntaxException e) {
-        throw new RuntimeException(e);
-      }
+    if (position > 0 && !contentUrl.toString().contains("rn=")) {
+      URI rangeUrl = getNextRangeUrl();
+
+      log.debug("Range URL: {}", rangeUrl.toString());
+
+      return rangeUrl;
     } else {
       return contentUrl;
     }
+  }
+
+  @Override
+  protected int internalRead(byte[] b, int off, int len, boolean attemptReconnect) throws IOException {
+    long nextExpectedPosition = position + len;
+
+    try {
+      connect(false);
+
+      int result;
+      if (nextExpectedPosition + (BUFFER_SIZE / 2) >= rangeEnd && rangeEnd != 0) {
+        if (rangeEnd == contentLength) {
+          result = currentContent.read(b, off, len);
+          position += result;
+        } else {
+          result = 0;
+          handleRangeEnd(null, attemptReconnect);
+        }
+      } else {
+        result = currentContent.read(b, off, len);
+        if (result >= 0) {
+          position += result;
+          if (position >= rangeEnd && !contentUrl.toString().contains("rn=")) {
+            handleRangeEnd(null, attemptReconnect);
+          }
+        }
+      }
+
+      return result;
+    } catch (IOException e) {
+      handleRangeEnd(e, attemptReconnect);
+      return internalRead(b, off, len, false);
+    }
+  }
+
+  @Override
+  protected long internalSkip(long n, boolean attemptReconnect) throws IOException {
+    long nextExpectedPosition = position + n;
+
+    try {
+      connect(false);
+
+      long result;
+      if (nextExpectedPosition + (BUFFER_SIZE / 2) >= rangeEnd && rangeEnd != 0) {
+        if (rangeEnd == contentLength) {
+          result = currentContent.skip(n);
+          position += result;
+        } else {
+          result = n;
+          position += n;
+          handleRangeEnd(null, attemptReconnect);
+        }
+      } else {
+        result = currentContent.skip(n);
+        if (result >= 0) {
+          position += result;
+          if (position >= rangeEnd && !contentUrl.toString().contains("rn=")) {
+            handleRangeEnd(null, attemptReconnect);
+          }
+        }
+      }
+
+      return result;
+    } catch (IOException e) {
+      handleRangeEnd(e, attemptReconnect);
+      return internalSkip(n, false);
+    }
+  }
+
+  private URI getNextRangeUrl() {
+    rangeEnd = position + BUFFER_SIZE;
+
+    if (rangeEnd > contentLength) {
+      rangeEnd = contentLength;
+    }
+
+    try {
+      return new URIBuilder(contentUrl).addParameter("range", position + "-" + rangeEnd).build();
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  protected void handleRangeEnd(IOException exception, boolean attemptReconnect) throws IOException {
+    if (!attemptReconnect || (!HttpClientTools.isRetriableNetworkException(exception) && exception != null)) {
+      throw exception;
+    }
+
+    close();
   }
 
   @Override

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeSearchMusicProvider.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeSearchMusicProvider.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
-import static com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeConstants.MUSIC_SEARCH_PAYLOAD;
 import static com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeConstants.MUSIC_SEARCH_URL;
 import static com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeConstants.WATCH_URL_PREFIX;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -47,12 +46,15 @@ public class YoutubeSearchMusicProvider implements YoutubeSearchMusicResultLoade
    */
   @Override
   public AudioItem loadSearchMusicResult(String query, Function<AudioTrackInfo, AudioTrack> trackFactory) {
-    String escapedQuery = query.replaceAll("\"|\\\\", "");
-    log.debug("Performing a search music with query {}", escapedQuery);
+    log.debug("Performing a search music with query {}", query);
 
     try (HttpInterface httpInterface = httpInterfaceManager.getInterface()) {
       HttpPost post = new HttpPost(MUSIC_SEARCH_URL);
-      StringEntity payload = new StringEntity(String.format(MUSIC_SEARCH_PAYLOAD, escapedQuery), "UTF-8");
+      String json = YoutubeClientConfig.MUSIC.copy()
+              .withRootQuery(query)
+              .withRootParams("Eg-KAQwIARAAGAAgACgAMABqChADEAQQCRAFEAo=")
+              .toJsonString();
+      StringEntity payload = new StringEntity(json, "UTF-8");
       post.setHeader("Referer", "music.youtube.com");
       post.setEntity(payload);
 

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeSearchMusicProvider.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeSearchMusicProvider.java
@@ -51,8 +51,8 @@ public class YoutubeSearchMusicProvider implements YoutubeSearchMusicResultLoade
     try (HttpInterface httpInterface = httpInterfaceManager.getInterface()) {
       HttpPost post = new HttpPost(MUSIC_SEARCH_URL);
       String json = YoutubeClientConfig.MUSIC.copy()
-              .withRootQuery(query)
-              .withRootParams("Eg-KAQwIARAAGAAgACgAMABqChADEAQQCRAFEAo=")
+              .withRootField("query", query)
+              .withRootField("params", "Eg-KAQwIARAAGAAgACgAMABqChADEAQQCRAFEAo=")
               .toJsonString();
       StringEntity payload = new StringEntity(json, "UTF-8");
       post.setHeader("Referer", "music.youtube.com");

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeSearchProvider.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeSearchProvider.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
-import static com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeConstants.SEARCH_PAYLOAD;
 import static com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeConstants.SEARCH_URL;
 import static com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeConstants.WATCH_URL_PREFIX;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -47,12 +46,16 @@ public class YoutubeSearchProvider implements YoutubeSearchResultLoader {
    */
   @Override
   public AudioItem loadSearchResult(String query, Function<AudioTrackInfo, AudioTrack> trackFactory) {
-    String escapedQuery = query.replaceAll("\"|\\\\", "");
-    log.debug("Performing a search with query {}", escapedQuery);
+    log.debug("Performing a search with query {}", query);
 
     try (HttpInterface httpInterface = httpInterfaceManager.getInterface()) {
       HttpPost post = new HttpPost(SEARCH_URL);
-      StringEntity payload = new StringEntity(String.format(SEARCH_PAYLOAD, escapedQuery), "UTF-8");
+      String json = YoutubeClientConfig.ANDROID_CLIENT.copy()
+              .withRootQuery(query)
+              .withRootParams("EgIQAQ==")
+              //.withClientDefaultScreenParameters()
+              .toJsonString();
+      StringEntity payload = new StringEntity(json, "UTF-8");
       post.setEntity(payload);
 
       try (CloseableHttpResponse response = httpInterface.execute(post)) {

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeSearchProvider.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeSearchProvider.java
@@ -50,7 +50,7 @@ public class YoutubeSearchProvider implements YoutubeSearchResultLoader {
 
     try (HttpInterface httpInterface = httpInterfaceManager.getInterface()) {
       HttpPost post = new HttpPost(SEARCH_URL);
-      String json = YoutubeClientConfig.ANDROID_CLIENT.copy()
+      String json = YoutubeClientConfig.ANDROID.copy()
               .withRootField("query", query)
               .withRootField("params", "EgIQAQ==")
               //.withClientDefaultScreenParameters()

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeSearchProvider.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeSearchProvider.java
@@ -51,8 +51,8 @@ public class YoutubeSearchProvider implements YoutubeSearchResultLoader {
     try (HttpInterface httpInterface = httpInterfaceManager.getInterface()) {
       HttpPost post = new HttpPost(SEARCH_URL);
       String json = YoutubeClientConfig.ANDROID_CLIENT.copy()
-              .withRootQuery(query)
-              .withRootParams("EgIQAQ==")
+              .withRootField("query", query)
+              .withRootField("params", "EgIQAQ==")
               //.withClientDefaultScreenParameters()
               .toJsonString();
       StringEntity payload = new StringEntity(json, "UTF-8");

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeSignatureCipherManager.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeSignatureCipherManager.java
@@ -124,8 +124,6 @@ public class YoutubeSignatureCipherManager implements YoutubeSignatureResolver {
       }
     }
 
-    log.info("nFunction resolved");
-
     try {
       return uri.setParameter("ratebypass", "yes").build();
     } catch (URISyntaxException e) {

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeSignatureCipherManager.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeSignatureCipherManager.java
@@ -124,6 +124,8 @@ public class YoutubeSignatureCipherManager implements YoutubeSignatureResolver {
       }
     }
 
+    log.info("nFunction resolved");
+
     try {
       return uri.setParameter("ratebypass", "yes").build();
     } catch (URISyntaxException e) {
@@ -243,6 +245,7 @@ public class YoutubeSignatureCipherManager implements YoutubeSignatureResolver {
     YoutubeSignatureCipher cipherKey = new YoutubeSignatureCipher();
 
     if (nFunction.find()) {
+      log.info("nFunction match");
       cipherKey.setNFunction(nFunction.group(0));
     } else {
       // Don't throw any exceptions here since if n function is not extracted audio still can be played

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeSignatureCipherManager.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeSignatureCipherManager.java
@@ -243,7 +243,6 @@ public class YoutubeSignatureCipherManager implements YoutubeSignatureResolver {
     YoutubeSignatureCipher cipherKey = new YoutubeSignatureCipher();
 
     if (nFunction.find()) {
-      log.info("nFunction match");
       cipherKey.setNFunction(nFunction.group(0));
     } else {
       // Don't throw any exceptions here since if n function is not extracted audio still can be played

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeTrackDetailsLoader.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeTrackDetailsLoader.java
@@ -4,4 +4,9 @@ import com.sedmelluq.discord.lavaplayer.tools.io.HttpInterface;
 
 public interface YoutubeTrackDetailsLoader {
   YoutubeTrackDetails loadDetails(HttpInterface httpInterface, String videoId, boolean requireFormats, YoutubeAudioSourceManager sourceManager);
+
+
+  default YoutubeTrackDetails loadDetails(HttpInterface httpInterface, String videoId, boolean requireFormats, YoutubeAudioSourceManager sourceManager, YoutubeClientConfig clientOverride) {
+    return this.loadDetails(httpInterface, videoId, requireFormats, sourceManager);
+  }
 }

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeTrackFormat.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeTrackFormat.java
@@ -4,6 +4,8 @@ import org.apache.http.entity.ContentType;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Describes an available media format for a track
@@ -18,6 +20,7 @@ public class YoutubeTrackFormat {
   private final String nParameter;
   private final String signature;
   private final String signatureKey;
+  private final String extra;
 
   /**
    * @param type Mime type of the format
@@ -37,7 +40,8 @@ public class YoutubeTrackFormat {
       String url,
       String nParameter,
       String signature,
-      String signatureKey
+      String signatureKey,
+      String extra
   ) {
     this.info = YoutubeFormatInfo.get(type);
     this.type = type;
@@ -48,6 +52,7 @@ public class YoutubeTrackFormat {
     this.nParameter = nParameter;
     this.signature = signature;
     this.signatureKey = signatureKey;
+    this.extra = extra;
   }
 
   /**
@@ -115,5 +120,9 @@ public class YoutubeTrackFormat {
    */
   public String getSignatureKey() {
     return signatureKey;
+  }
+
+  public String getExtra() {
+    return this.extra;
   }
 }

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/format/LegacyAdaptiveFormatsExtractor.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/format/LegacyAdaptiveFormatsExtractor.java
@@ -6,6 +6,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.apache.http.entity.ContentType;
 
 import static com.sedmelluq.discord.lavaplayer.tools.DataFormatTools.decodeUrlEncodedItems;
@@ -36,7 +38,8 @@ public class LegacyAdaptiveFormatsExtractor implements OfflineYoutubeTrackFormat
           format.get("url"),
           "",
           format.get("s"),
-          format.getOrDefault("sp", DEFAULT_SIGNATURE_KEY)
+          format.getOrDefault("sp", DEFAULT_SIGNATURE_KEY),
+          format.entrySet().stream().map(item -> item.getKey() + "=" + item.getValue()).collect(Collectors.joining(","))
       ));
     }
 

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/format/LegacyDashMpdFormatsExtractor.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/format/LegacyDashMpdFormatsExtractor.java
@@ -83,7 +83,8 @@ public class LegacyDashMpdFormatsExtractor implements YoutubeTrackFormatExtracto
             url,
             "",
             null,
-            DEFAULT_SIGNATURE_KEY
+            DEFAULT_SIGNATURE_KEY,
+            ""
         ));
       }
     }

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/format/LegacyStreamMapFormatsExtractor.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/format/LegacyStreamMapFormatsExtractor.java
@@ -7,6 +7,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.apache.http.entity.ContentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,7 +57,8 @@ public class LegacyStreamMapFormatsExtractor implements OfflineYoutubeTrackForma
             url,
             "",
             format.get("s"),
-            format.getOrDefault("sp", DEFAULT_SIGNATURE_KEY)
+            format.getOrDefault("sp", DEFAULT_SIGNATURE_KEY),
+            format.entrySet().stream().map(item -> item.getKey() + "=" + item.getValue()).collect(Collectors.joining(","))
         ));
       } catch (RuntimeException e) {
         anyFailures = true;

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/format/StreamingDataFormatsExtractor.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/format/StreamingDataFormatsExtractor.java
@@ -88,8 +88,8 @@ public class StreamingDataFormatsExtractor implements OfflineYoutubeTrackFormatE
     }
 
     if (tracks.isEmpty() && anyFailures) {
-      log.warn("In streamingData adaptive formats {}, all formats either failed to load or were skipped due to missing " +
-          "fields", formats.format());
+      log.warn("In streamingData adaptive formats {}, all formats either failed to load or were skipped due to missing fields",
+              formats.format());
     }
 
     return tracks;

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/format/StreamingDataFormatsExtractor.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/format/StreamingDataFormatsExtractor.java
@@ -77,7 +77,8 @@ public class StreamingDataFormatsExtractor implements OfflineYoutubeTrackFormatE
               cipherInfo.getOrDefault("url", url),
               urlMap.get("n"),
               cipherInfo.get("s"),
-              cipherInfo.getOrDefault("sp", DEFAULT_SIGNATURE_KEY)
+              cipherInfo.getOrDefault("sp", DEFAULT_SIGNATURE_KEY),
+              formatJson.format()
           ));
         } catch (RuntimeException e) {
           anyFailures = true;

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/io/PersistentHttpStream.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/io/PersistentHttpStream.java
@@ -34,7 +34,7 @@ public class PersistentHttpStream extends SeekableInputStream implements AutoClo
   protected final URI contentUrl;
   private int lastStatusCode;
   private CloseableHttpResponse currentResponse;
-  private InputStream currentContent;
+  protected InputStream currentContent;
   protected long position;
 
   /**
@@ -99,7 +99,7 @@ public class PersistentHttpStream extends SeekableInputStream implements AutoClo
     return request;
   }
 
-  private void connect(boolean skipStatusCheck) throws IOException {
+  protected void connect(boolean skipStatusCheck) throws IOException {
     if (currentResponse == null) {
       for (int i = 1; i >= 0; i--) {
         if (attemptConnect(skipStatusCheck, i > 0)) {
@@ -146,7 +146,7 @@ public class PersistentHttpStream extends SeekableInputStream implements AutoClo
     log.debug("Encountered retriable exception on url {}.", contentUrl, exception);
   }
 
-  private int internalRead(boolean attemptReconnect) throws IOException {
+  protected int internalRead(boolean attemptReconnect) throws IOException {
     connect(false);
 
     try {
@@ -166,7 +166,7 @@ public class PersistentHttpStream extends SeekableInputStream implements AutoClo
     return internalRead(true);
   }
 
-  private int internalRead(byte[] b, int off, int len, boolean attemptReconnect) throws IOException {
+  protected int internalRead(byte[] b, int off, int len, boolean attemptReconnect) throws IOException {
     connect(false);
 
     try {
@@ -186,7 +186,7 @@ public class PersistentHttpStream extends SeekableInputStream implements AutoClo
     return internalRead(b, off, len, true);
   }
 
-  private long internalSkip(long n, boolean attemptReconnect) throws IOException {
+  protected long internalSkip(long n, boolean attemptReconnect) throws IOException {
     connect(false);
 
     try {

--- a/main/src/test/java/com/sedmelluq/discord/lavaplayer/integration/FormatCipherTest.java
+++ b/main/src/test/java/com/sedmelluq/discord/lavaplayer/integration/FormatCipherTest.java
@@ -1,0 +1,35 @@
+package com.sedmelluq.discord.lavaplayer.integration;
+
+import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager;
+import com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager;
+import com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeAudioSourceManager;
+import com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeClientConfig;
+import com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeTrackDetails;
+import com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeTrackFormat;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class FormatCipherTest {
+
+    public static void main(String[] args) {
+        AudioPlayerManager apm = new DefaultAudioPlayerManager();
+        YoutubeAudioSourceManager yt = new YoutubeAudioSourceManager();
+        apm.registerSourceManager(yt);
+
+        YoutubeClientConfig config = new YoutubeClientConfig()
+                .withClientName("WEB")
+                .withClientField("clientVersion", "2.20220918");
+
+        YoutubeTrackDetails details = yt.getTrackDetailsLoader().loadDetails(yt.getHttpInterface(), "dNUHmLHkKXI", true, yt, config);
+        List<YoutubeTrackFormat> formats = details.getFormats(yt.getHttpInterface(), yt.getSignatureResolver());
+
+        formats.stream()
+                .filter(format -> format.getInfo() != null)
+                .filter(format -> "audio/webm".equals(format.getInfo().mimeType))
+                .sorted(Comparator.comparingLong(YoutubeTrackFormat::getBitrate).reversed())
+                .forEach(format -> System.out.printf("opus %dk %dc ciphered? %b%n", (format.getBitrate() / 1024), format.getAudioChannels(), format.getSignature() != null));
+    }
+
+}


### PR DESCRIPTION
The `BandcampAudioTrack` currently assumes that a media URL will always exist for the resource, however this is not the case for <https://geometriclullaby.bandcamp.com/track/side-a-rune>. After doing some digging, there are no formats available for this track, and no media player on the website so it has most likely been locked.