### PR TITLE
AudioSourceManagers getter in AudioPlayerManager

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/player/AudioPlayerManager.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/player/AudioPlayerManager.java
@@ -8,6 +8,7 @@ import com.sedmelluq.discord.lavaplayer.track.AudioReference;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
 import com.sedmelluq.discord.lavaplayer.track.DecodedTrackHolder;
 import java.io.IOException;
+import java.util.List;
 import java.util.concurrent.Future;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -54,6 +55,11 @@ public interface AudioPlayerManager {
    * @return The source manager of the specified class, or null if not registered.
    */
   <T extends AudioSourceManager> T source(Class<T> klass);
+
+  /**
+   * @return A list of all registered audio source managers.
+   */
+  List<AudioSourceManager> getSourceManagers();
 
   /**
    * Schedules loading a track or playlist with the specified identifier.

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/player/DefaultAudioPlayerManager.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/player/DefaultAudioPlayerManager.java
@@ -34,6 +34,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Callable;
@@ -180,6 +181,11 @@ public class DefaultAudioPlayerManager implements AudioPlayerManager {
     }
 
     return null;
+  }
+
+  @Override
+  public List<AudioSourceManager> getSourceManagers() {
+    return Collections.unmodifiableList(sourceManagers);
   }
 
   @Override


### PR DESCRIPTION
it would be helpful to have a getter for all registered audio source managers.
We want to return all registered audio source managers in part of the new `/info` endpoint to display a nodes capabilities 