### PR TITLE
Adding a warning when soundcloud track is a demo from SoundCloud GO+

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/soundcloud/DefaultSoundCloudDataReader.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/soundcloud/DefaultSoundCloudDataReader.java
@@ -22,15 +22,22 @@ public class DefaultSoundCloudDataReader implements SoundCloudDataReader {
 
   @Override
   public boolean isTrackBlocked(JsonBrowser trackData) {
-    return "BLOCK".equals(trackData.get("policy").safeText());
+    return "BLOCK".equals(trackData.get("policy").safeText()) || "SUB_HIGH_TIER".equals(trackData.get("monetization_model").safeText());
   }
 
   @Override
   public AudioTrackInfo readTrackInfo(JsonBrowser trackData, String identifier) {
+    String title = trackData.get("title").safeText();
+    Integer duration = trackData.get("full_duration").as(Integer.class);
+    if("SUB_HIGH_TIER".equals(trackData.get("monetization_model").safeText())) {
+      title = "SoundCloud GO+ Demo: " + title;
+      duration = 30000;
+    }
+
     return new AudioTrackInfo(
-        trackData.get("title").safeText(),
+        title,
         trackData.get("user").get("username").safeText(),
-        trackData.get("full_duration").as(Integer.class),
+        duration,
         identifier,
         false,
         trackData.get("permalink_url").text()

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/soundcloud/DefaultSoundCloudDataReader.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/soundcloud/DefaultSoundCloudDataReader.java
@@ -1,7 +1,6 @@
 package com.sedmelluq.discord.lavaplayer.source.soundcloud;
 
 import com.sedmelluq.discord.lavaplayer.tools.JsonBrowser;
-import com.sedmelluq.discord.lavaplayer.track.AudioTrackInfo;
 import java.util.ArrayList;
 import java.util.List;
 import org.slf4j.Logger;
@@ -26,21 +25,22 @@ public class DefaultSoundCloudDataReader implements SoundCloudDataReader {
   }
 
   @Override
-  public AudioTrackInfo readTrackInfo(JsonBrowser trackData, String identifier) {
-    String title = trackData.get("title").safeText();
+  public SoundCloudAudioTrackInfo readTrackInfo(JsonBrowser trackData, String identifier) {
     Integer duration = trackData.get("full_duration").as(Integer.class);
-    if("SUB_HIGH_TIER".equals(trackData.get("monetization_model").safeText())) {
-      title = "SoundCloud GO+ Demo: " + title;
+    boolean isDemo = false;
+    if ("SUB_HIGH_TIER".equals(trackData.get("monetization_model").safeText())) {
       duration = 30000;
+      isDemo = true;
     }
 
-    return new AudioTrackInfo(
-        title,
-        trackData.get("user").get("username").safeText(),
-        duration,
-        identifier,
-        false,
-        trackData.get("permalink_url").text()
+    return new SoundCloudAudioTrackInfo(
+            trackData.get("title").safeText(),
+            trackData.get("user").get("username").safeText(),
+            duration,
+            identifier,
+            false,
+            trackData.get("permalink_url").text(),
+            isDemo
     );
   }
 

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/soundcloud/SoundCloudAudioTrackInfo.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/soundcloud/SoundCloudAudioTrackInfo.java
@@ -1,0 +1,57 @@
+package com.sedmelluq.discord.lavaplayer.source.soundcloud;
+
+import com.sedmelluq.discord.lavaplayer.track.AudioTrackInfo;
+
+/**
+ * Meta info for an audio track
+ */
+public class SoundCloudAudioTrackInfo extends AudioTrackInfo {
+    /**
+     * Track title
+     */
+    public final String title;
+    /**
+     * Track author, if known
+     */
+    public final String author;
+    /**
+     * Length of the track in milliseconds, UnitConstants.DURATION_MS_UNKNOWN for streams
+     */
+    public final long length;
+    /**
+     * Audio source specific track identifier
+     */
+    public final String identifier;
+    /**
+     * True if this track is a stream
+     */
+    public final boolean isStream;
+    /**
+     * URL of the track, or local path to the file.
+     */
+    public final String uri;
+    /*
+    * Whether the track is a SoundCloud GO+ Demo
+    * */
+    public final boolean isDemo;
+
+    /**
+     * @param title Track title
+     * @param author Track author, if known
+     * @param length Length of the track in milliseconds
+     * @param identifier Audio source specific track identifier
+     * @param isStream True if this track is a stream
+     * @param uri URL of the track or path to its file.
+     */
+
+    public SoundCloudAudioTrackInfo(String title, String author, long length, String identifier, boolean isStream, String uri, Boolean isDemo) {
+        super(title, author, length, identifier, isStream, uri);
+        this.title = title;
+        this.author = author;
+        this.length = length;
+        this.identifier = identifier;
+        this.isStream = isStream;
+        this.uri = uri;
+        this.isDemo = isDemo;
+    }
+}

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/soundcloud/SoundCloudDataReader.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/soundcloud/SoundCloudDataReader.java
@@ -1,7 +1,6 @@
 package com.sedmelluq.discord.lavaplayer.source.soundcloud;
 
 import com.sedmelluq.discord.lavaplayer.tools.JsonBrowser;
-import com.sedmelluq.discord.lavaplayer.track.AudioTrackInfo;
 import java.util.List;
 
 public interface SoundCloudDataReader {
@@ -11,7 +10,7 @@ public interface SoundCloudDataReader {
 
   boolean isTrackBlocked(JsonBrowser trackData);
 
-  AudioTrackInfo readTrackInfo(JsonBrowser trackData, String identifier);
+  SoundCloudAudioTrackInfo readTrackInfo(JsonBrowser trackData, String identifier);
 
   List<SoundCloudTrackFormat> readTrackFormats(JsonBrowser trackData);
 


### PR DESCRIPTION
This PR is related to #67 

When a SoundCloud track has the property `"monetization_model":"SUB_HIGH_TIER"` means its a 30 second demo from the full track, this PR just adds a `isDemo` property on a `SoundCloudAudioTrackInfo` class and sets the duration of the track to 30 seconds.

Example usage:
```java
if(track.getSourceManager() instanceof SoundCloudAudioSourceManager) {
  SoundCloudAudioTrackInfo info = (SoundCloudAudioTrackInfo) track.getInfo();
  if(info.isDemo) 
    System.out.println("The track is a 30 second demo")
}
```