### PR TITLE
fix artworkUrl track version

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/player/DefaultAudioPlayerManager.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/player/DefaultAudioPlayerManager.java
@@ -276,7 +276,7 @@ public class DefaultAudioPlayerManager implements AudioPlayerManager {
         input.readUTF(),
         input.readBoolean(),
         version >= 2 ? DataFormatTools.readNullableText(input) : null,
-        version >= 2 ? DataFormatTools.readNullableText(input) : null,
+        version >= 3 ? DataFormatTools.readNullableText(input) : null,
         version >= 3 ? DataFormatTools.readNullableText(input) : null
     );
     AudioTrack track = decodeTrackDetails(trackInfo, input);


### PR DESCRIPTION
The `artworkUrl` field should not be track version 2 to make the `original` branch tracks properly work with the `custom` branch