### PR TITLE
Support YouTube Audio Tracks

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioTrack.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioTrack.java
@@ -122,6 +122,10 @@ public class YoutubeAudioTrack extends DelegatedAudioTrack {
     YoutubeTrackFormat bestFormat = null;
 
     for (YoutubeTrackFormat format : formats) {
+      if (!format.isDefaultAudioTrack()) {
+        continue;
+      }
+
       if (isBetterFormat(format, bestFormat)) {
         bestFormat = format;
       }

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeTrackFormat.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeTrackFormat.java
@@ -18,6 +18,7 @@ public class YoutubeTrackFormat {
   private final String nParameter;
   private final String signature;
   private final String signatureKey;
+  private final boolean defaultAudioTrack;
 
   /**
    * @param type Mime type of the format
@@ -37,7 +38,8 @@ public class YoutubeTrackFormat {
       String url,
       String nParameter,
       String signature,
-      String signatureKey
+      String signatureKey,
+      boolean isDefaultAudioTrack
   ) {
     this.info = YoutubeFormatInfo.get(type);
     this.type = type;
@@ -48,6 +50,7 @@ public class YoutubeTrackFormat {
     this.nParameter = nParameter;
     this.signature = signature;
     this.signatureKey = signatureKey;
+    this.defaultAudioTrack = isDefaultAudioTrack;
   }
 
   /**
@@ -115,5 +118,12 @@ public class YoutubeTrackFormat {
    */
   public String getSignatureKey() {
     return signatureKey;
+  }
+
+  /**
+   * @return Whether this format contains an audio track that is used by default.
+   */
+  public boolean isDefaultAudioTrack() {
+    return defaultAudioTrack;
   }
 }

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/format/LegacyAdaptiveFormatsExtractor.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/format/LegacyAdaptiveFormatsExtractor.java
@@ -36,7 +36,8 @@ public class LegacyAdaptiveFormatsExtractor implements OfflineYoutubeTrackFormat
           format.get("url"),
           "",
           format.get("s"),
-          format.getOrDefault("sp", DEFAULT_SIGNATURE_KEY)
+          format.getOrDefault("sp", DEFAULT_SIGNATURE_KEY),
+          true
       ));
     }
 

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/format/LegacyDashMpdFormatsExtractor.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/format/LegacyDashMpdFormatsExtractor.java
@@ -83,7 +83,8 @@ public class LegacyDashMpdFormatsExtractor implements YoutubeTrackFormatExtracto
             url,
             "",
             null,
-            DEFAULT_SIGNATURE_KEY
+            DEFAULT_SIGNATURE_KEY,
+            true
         ));
       }
     }

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/format/LegacyStreamMapFormatsExtractor.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/format/LegacyStreamMapFormatsExtractor.java
@@ -55,7 +55,8 @@ public class LegacyStreamMapFormatsExtractor implements OfflineYoutubeTrackForma
             url,
             "",
             format.get("s"),
-            format.getOrDefault("sp", DEFAULT_SIGNATURE_KEY)
+            format.getOrDefault("sp", DEFAULT_SIGNATURE_KEY),
+            true
         ));
       } catch (RuntimeException e) {
         anyFailures = true;

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/format/StreamingDataFormatsExtractor.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/format/StreamingDataFormatsExtractor.java
@@ -77,7 +77,8 @@ public class StreamingDataFormatsExtractor implements OfflineYoutubeTrackFormatE
               cipherInfo.getOrDefault("url", url),
               urlMap.get("n"),
               cipherInfo.get("s"),
-              cipherInfo.getOrDefault("sp", DEFAULT_SIGNATURE_KEY)
+              cipherInfo.getOrDefault("sp", DEFAULT_SIGNATURE_KEY),
+              formatJson.get("audioTrack").get("audioIsDefault").asBoolean(true)
           ));
         } catch (RuntimeException e) {
           anyFailures = true;


### PR DESCRIPTION
A youtube video can contain multiple audio tracks, this PR makes it so that lavaplayer only looks for formats that are used by default.

Example video:
https://www.youtube.com/watch?v=TJ2ifmkGGus