### PR TITLE
Upgrade dependencies to resolve reported vulnerabilities.

### DIFF
--- a/main/build.gradle.kts
+++ b/main/build.gradle.kts
@@ -15,6 +15,12 @@ dependencies {
   api("org.slf4j:slf4j-api:1.7.36")
 
   api("org.apache.httpcomponents:httpclient:4.5.14")
+  constraints {
+    implementation("commons-codec:commons-codec:1.15") {
+      because("Cxeb68d52e-5509 at version 1.11 and below.")
+    }
+  }
+
   implementation("commons-io:commons-io:2.11.0")
 
   api("com.fasterxml.jackson.core:jackson-core:2.12.7")

--- a/main/build.gradle.kts
+++ b/main/build.gradle.kts
@@ -12,21 +12,21 @@ dependencies {
   implementation("com.github.walkyst:lavaplayer-natives-fork:1.0.1")
   implementation("com.github.walkyst.JAADec-fork:jaadec-ext-aac:0.1.3")
   implementation("org.mozilla:rhino-engine:1.7.14")
-  api("org.slf4j:slf4j-api:1.7.25")
+  api("org.slf4j:slf4j-api:1.7.36")
 
-  api("org.apache.httpcomponents:httpclient:4.5.10")
-  implementation("commons-io:commons-io:2.6")
+  api("org.apache.httpcomponents:httpclient:4.5.14")
+  implementation("commons-io:commons-io:2.11.0")
 
-  api("com.fasterxml.jackson.core:jackson-core:2.10.0")
-  api("com.fasterxml.jackson.core:jackson-databind:2.10.0")
+  api("com.fasterxml.jackson.core:jackson-core:2.12.7")
+  api("com.fasterxml.jackson.core:jackson-databind:2.12.7.1")
 
-  implementation("org.jsoup:jsoup:1.12.1")
+  implementation("org.jsoup:jsoup:1.15.4")
   implementation("net.iharder:base64:2.3.9")
   implementation("org.json:json:20220924")
 
-  testImplementation("org.codehaus.groovy:groovy:2.5.5")
+  testImplementation("org.codehaus.groovy:groovy:2.5.14")
   testImplementation("org.spockframework:spock-core:1.2-groovy-2.5")
-  testImplementation("ch.qos.logback:logback-classic:1.2.3")
+  testImplementation("ch.qos.logback:logback-classic:1.2.9")
   testImplementation("com.sedmelluq:lavaplayer-test-samples:1.3.11")
 }
 

--- a/main/build.gradle.kts
+++ b/main/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 val moduleName = "lavaplayer"
-version = "1.4.0-original"
+version = "1.4.1-original"
 
 dependencies {
   api("com.sedmelluq:lava-common:1.1.2")


### PR DESCRIPTION
Just updating a few dependencies that are flagging some vulnerabilities up.

Ran a `clean build` locally and everything went green.

I've tried to keep versions similar to what was already being used other than in a couple of instances where the further upgrades are necessary.