### PR TITLE
musl support

### DIFF
--- a/common/src/main/java/com/sedmelluq/lava/common/natives/architecture/DefaultOperatingSystemTypes.java
+++ b/common/src/main/java/com/sedmelluq/lava/common/natives/architecture/DefaultOperatingSystemTypes.java
@@ -1,10 +1,21 @@
 package com.sedmelluq.lava.common.natives.architecture;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
 public enum DefaultOperatingSystemTypes implements OperatingSystemType {
   LINUX("linux", "lib", ".so"),
+  LINUX_MUSL("linux-musl", "lib", ".so"),
   WINDOWS("win", "", ".dll"),
   DARWIN("darwin", "lib", ".dylib"),
   SOLARIS("solaris", "lib", ".so");
+
+  private static final Logger log = LoggerFactory.getLogger(DefaultOperatingSystemTypes.class);
+  private static volatile Boolean cachedMusl;
 
   private final String identifier;
   private final String libraryFilePrefix;
@@ -34,16 +45,43 @@ public enum DefaultOperatingSystemTypes implements OperatingSystemType {
   public static OperatingSystemType detect() {
     String osFullName = System.getProperty("os.name");
 
-    if (osFullName.startsWith("Windows")) {
+    if(osFullName.startsWith("Windows")) {
       return WINDOWS;
-    } else if (osFullName.startsWith("Mac OS X")) {
+    } else if(osFullName.startsWith("Mac OS X")) {
       return DARWIN;
-    } else if (osFullName.startsWith("Solaris")) {
+    } else if(osFullName.startsWith("Solaris")) {
       return SOLARIS;
-    } else if (osFullName.toLowerCase().startsWith("linux")) {
-      return LINUX;
+    } else if(osFullName.toLowerCase().startsWith("linux")) {
+      return checkMusl() ? LINUX_MUSL : LINUX;
     } else {
       throw new IllegalArgumentException("Unknown operating system: " + osFullName);
     }
+  }
+
+  private static boolean checkMusl() {
+    Boolean b = cachedMusl;
+    if(b == null) {
+      synchronized(DefaultOperatingSystemTypes.class) {
+        boolean check;
+        try {
+          Process p = new ProcessBuilder("ldd", "--version")
+                  .start();
+          log.debug("Exit code: {}", p.waitFor());
+          String line = new BufferedReader(new InputStreamReader(p.getInputStream())).readLine();
+          log.debug("First line of stdout: {}", line);
+          if(line == null) {
+            line = new BufferedReader(new InputStreamReader(p.getErrorStream())).readLine();
+            log.debug("First line of stderr: {}", line);
+          }
+          check = line != null && line.toLowerCase().startsWith("musl");
+        } catch(IOException | InterruptedException fail) {
+          log.error("Failed to detect libc type, assuming glibc", fail);
+          check = false;
+        }
+        log.debug("is musl: {}", check);
+        b = cachedMusl = check;
+      }
+    }
+    return b;
   }
 }

--- a/main/build.gradle.kts
+++ b/main/build.gradle.kts
@@ -9,7 +9,7 @@ version = "1.4.1-original"
 
 dependencies {
   api("com.sedmelluq:lava-common:1.1.2")
-  implementation("com.github.topisenpai:lavaplayer-natives-fork:aeebbbc724")
+  implementation("com.github.topisenpai:lavaplayer-natives-fork:a4b538444f")
   implementation("com.github.walkyst.JAADec-fork:jaadec-ext-aac:0.1.3")
   implementation("org.mozilla:rhino-engine:1.7.14")
   api("org.slf4j:slf4j-api:1.7.25")

--- a/main/build.gradle.kts
+++ b/main/build.gradle.kts
@@ -9,7 +9,7 @@ version = "1.4.1-original"
 
 dependencies {
   api("com.sedmelluq:lava-common:1.1.2")
-  implementation("com.github.topisenpai:lavaplayer-natives-fork:a4b538444f")
+  implementation("com.github.walkyst:lavaplayer-natives-fork:1.0.2")
   implementation("com.github.walkyst.JAADec-fork:jaadec-ext-aac:0.1.3")
   implementation("org.mozilla:rhino-engine:1.7.14")
   api("org.slf4j:slf4j-api:1.7.25")

--- a/main/build.gradle.kts
+++ b/main/build.gradle.kts
@@ -9,7 +9,7 @@ version = "1.4.0-original"
 
 dependencies {
   api("com.sedmelluq:lava-common:1.1.2")
-  implementation("com.github.walkyst:lavaplayer-natives-fork:1.0.1")
+  implementation("com.github.topisenpai:lavaplayer-natives-fork:aeebbbc724")
   implementation("com.github.walkyst.JAADec-fork:jaadec-ext-aac:0.1.3")
   implementation("org.mozilla:rhino-engine:1.7.14")
   api("org.slf4j:slf4j-api:1.7.25")


### PR DESCRIPTION
This pr adds support for detecting musl environments, and loading the appropriate native files. This is based on https://github.com/natanbc/native-loader

This pr depends on https://github.com/Walkyst/lavaplayer-natives-fork/pull/3 and is gonna stay as draft until the other is completed & merged