### PR TITLE
Add support for Soundcloud short URLs

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/soundcloud/SoundCloudAudioSourceManager.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/soundcloud/SoundCloudAudioSourceManager.java
@@ -47,6 +47,7 @@ public class SoundCloudAudioSourceManager implements AudioSourceManager, HttpCon
 
   private static final String MOBILE_URL_REGEX = "^(?:http://|https://|)soundcloud\\.app\\.goo\\.gl/([a-zA-Z0-9-_]+)/?(?:\\?.*|)$";
   private static final String TRACK_URL_REGEX = "^(?:http://|https://|)(?:www\\.|)(?:m\\.|)soundcloud\\.com/([a-zA-Z0-9-_]+)/([a-zA-Z0-9-_]+)/?(?:\\?.*|)$";
+  private static final String SHORT_TRACK_URL_REGEX = "^https://on.soundcloud\\.com/[a-zA-Z0-9-_]+/?(?:\\?.*|)$";
   private static final String UNLISTED_URL_REGEX = "^(?:http://|https://|)(?:www\\.|)(?:m\\.|)soundcloud\\.com/([a-zA-Z0-9-_]+)/([a-zA-Z0-9-_]+)/s-([a-zA-Z0-9-_]+)(?:\\?.*|)$";
   private static final String LIKED_URL_REGEX = "^(?:http://|https://|)(?:www\\.|)(?:m\\.|)soundcloud\\.com/([a-zA-Z0-9-_]+)/likes/?(?:\\?.*|)$";
   private static final String LIKED_USER_URN_REGEX = "\"urn\":\"soundcloud:users:([0-9]+)\",\"username\":\"([^\"]+)\"";
@@ -56,6 +57,7 @@ public class SoundCloudAudioSourceManager implements AudioSourceManager, HttpCon
 
   private static final Pattern mobileUrlPattern = Pattern.compile(MOBILE_URL_REGEX);
   private static final Pattern trackUrlPattern = Pattern.compile(TRACK_URL_REGEX);
+  private static final Pattern shortTrackUrlPattern = Pattern.compile(SHORT_TRACK_URL_REGEX);
   private static final Pattern unlistedUrlPattern = Pattern.compile(UNLISTED_URL_REGEX);
   private static final Pattern likedUrlPattern = Pattern.compile(LIKED_URL_REGEX);
   private static final Pattern likedUserUrnPattern = Pattern.compile(LIKED_USER_URN_REGEX);
@@ -118,6 +120,11 @@ public class SoundCloudAudioSourceManager implements AudioSourceManager, HttpCon
     Matcher mobileUrlMatcher = mobileUrlPattern.matcher(reference.identifier);
     if (mobileUrlMatcher.matches()) {
       reference = SoundCloudHelper.redirectMobileLink(httpInterfaceManager.getInterface(), reference);
+    }
+
+    Matcher shortTrackMatcher = shortTrackUrlPattern.matcher(reference.identifier);
+    if (shortTrackMatcher.matches()) {
+      reference = SoundCloudHelper.resolveShortTrackUrl(httpInterfaceManager.getInterface(), reference);
     }
 
     AudioItem track = processAsSingleTrack(reference);

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/soundcloud/SoundCloudHelper.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/soundcloud/SoundCloudHelper.java
@@ -1,5 +1,6 @@
 package com.sedmelluq.discord.lavaplayer.source.soundcloud;
 
+import com.sedmelluq.discord.lavaplayer.tools.DataFormatTools;
 import com.sedmelluq.discord.lavaplayer.tools.ExceptionTools;
 import com.sedmelluq.discord.lavaplayer.tools.FriendlyException;
 import com.sedmelluq.discord.lavaplayer.tools.JsonBrowser;
@@ -7,12 +8,14 @@ import com.sedmelluq.discord.lavaplayer.tools.io.HttpClientTools;
 import com.sedmelluq.discord.lavaplayer.tools.io.HttpInterface;
 import com.sedmelluq.discord.lavaplayer.tools.io.PersistentHttpStream;
 import com.sedmelluq.discord.lavaplayer.track.AudioReference;
+import org.apache.commons.io.IOUtils;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.protocol.HttpClientContext;
 
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static com.sedmelluq.discord.lavaplayer.tools.FriendlyException.Severity.SUSPICIOUS;
@@ -48,6 +51,21 @@ public class SoundCloudHelper {
         throw new FriendlyException("Unable to process soundcloud mobile link", SUSPICIOUS,
             new IllegalStateException("Expected soundcloud to redirect soundcloud.app.goo.gl link to a valid track/playlist link, but it did not redirect at all"));
       }
+    } catch (Exception e) {
+      throw ExceptionTools.wrapUnfriendlyExceptions(e);
+    }
+  }
+
+  public static AudioReference resolveShortTrackUrl(HttpInterface httpInterface, AudioReference reference) {
+    try (CloseableHttpResponse response = httpInterface.execute(new HttpGet(reference.identifier))) {
+      HttpClientTools.assertSuccessWithContent(response, "short url resolution");
+      String responseText = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
+      String url = DataFormatTools.extractBetween(responseText, "<link rel=\"canonical\" href=\"", "\">");
+      if (url == null) {
+        throw new FriendlyException("Unable to resolve Soundcloud short URL", SUSPICIOUS,
+            new IllegalStateException("Unable to locate canonical URL"));
+      }
+      return new AudioReference(url, null);
     } catch (Exception e) {
       throw ExceptionTools.wrapUnfriendlyExceptions(e);
     }


### PR DESCRIPTION
Adds support for shortened Soundcloud URLs. One example is https://on.soundcloud.com/D2ipz