### PR TITLE
update youtube search param to include video & show exact results

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeConstants.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeConstants.java
@@ -22,7 +22,7 @@ public class YoutubeConstants {
     static final String CLIENT_SCREEN_EMBED = "EMBED";
     static final String CLIENT_THIRD_PARTY_EMBED = "https://google.com";
     static final String PLAYER_PARAMS = "8AEB";
-    static final String SEARCH_PARAMS = "EgIQAQ==";
+    static final String SEARCH_PARAMS = "EgIQAUICCAE%253D";
 
     static final String SEARCH_URL = BASE_URL + "/search?key=" + INNERTUBE_ANDROID_API_KEY;
     static final String PLAYER_URL = BASE_URL + "/player";


### PR DESCRIPTION
the old search param `EgIQAQ==` was used to filter for videos only.
the updated also shows exact results only `EgIQAUICCAE%253D`

you can obtain these by combining various filters & copying the `sp` query params
![image](https://github.com/Walkyst/lavaplayer-fork/assets/15636011/bc2f4f3f-30a5-4786-b391-6ffc6f3affdf)
