### PR TITLE
Bump dependencies to fix vulnerabilities

### DIFF
--- a/main/build.gradle.kts
+++ b/main/build.gradle.kts
@@ -12,21 +12,21 @@ dependencies {
   implementation("com.github.walkyst:lavaplayer-natives-fork:1.0.2")
   implementation("com.github.walkyst.JAADec-fork:jaadec-ext-aac:0.1.3")
   implementation("org.mozilla:rhino-engine:1.7.14")
-  api("org.slf4j:slf4j-api:1.7.25")
+  api("org.slf4j:slf4j-api:2.0.9")
 
-  api("org.apache.httpcomponents:httpclient:4.5.10")
-  implementation("commons-io:commons-io:2.6")
+  api("org.apache.httpcomponents:httpclient:4.5.13")
+  implementation("commons-io:commons-io:2.15.1")
 
   api("com.fasterxml.jackson.core:jackson-core:2.10.0")
-  api("com.fasterxml.jackson.core:jackson-databind:2.10.0")
+  api("com.fasterxml.jackson.core:jackson-databind:2.16.0")
 
-  implementation("org.jsoup:jsoup:1.12.1")
+  implementation("org.jsoup:jsoup:1.15.3")
   implementation("net.iharder:base64:2.3.9")
-  implementation("org.json:json:20220924")
+  implementation("org.json:json:20231013")
 
-  testImplementation("org.codehaus.groovy:groovy:2.5.5")
-  testImplementation("org.spockframework:spock-core:1.2-groovy-2.5")
-  testImplementation("ch.qos.logback:logback-classic:1.2.3")
+  testImplementation("org.codehaus.groovy:groovy:2.5.14")
+  testImplementation("org.spockframework:spock-core:2.4-M1")
+  testImplementation("ch.qos.logback:logback-classic:1.4.12")
   testImplementation("com.sedmelluq:lavaplayer-test-samples:1.3.11")
 }
 

--- a/main/build.gradle.kts
+++ b/main/build.gradle.kts
@@ -24,8 +24,8 @@ dependencies {
   implementation("net.iharder:base64:2.3.9")
   implementation("org.json:json:20231013")
 
-  testImplementation("org.codehaus.groovy:groovy:2.5.14")
-  testImplementation("org.spockframework:spock-core:2.4-M1")
+  testImplementation("org.apache.groovy:groovy-all:4.0.6")
+  testImplementation("org.spockframework:spock-core:2.4-M1-groovy-4.0")
   testImplementation("ch.qos.logback:logback-classic:1.4.12")
   testImplementation("com.sedmelluq:lavaplayer-test-samples:1.3.11")
 }


### PR DESCRIPTION
Bump dependencies to fix CVEs.
- httpclient4 was not upgraded due to httpclient5 not being a drop-in replacement.
- groovy was moved to apache.groovy

Build was successful. Maybe I'll try httpclient5 later, but I first changed dependencies without problems when building. Some packages might be old since some packages were updated to minimum version without CVE, in case of incompatibility. If required I'll check them and make commits.